### PR TITLE
Isolate Python test dependencies with a virtual environment in bootstrap.sh

### DIFF
--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -26,9 +26,12 @@ echo " -> npm install in examples/node-gate-publisher"
 (cd "$ROOT_DIR/examples/node-gate-publisher" && npm install)
 
 echo ""
+echo "==> Setting up Python virtual environment"
+(test -d "$ROOT_DIR/.venv" || python3 -m venv "$ROOT_DIR/.venv")
+
 echo "==> Installing Python test dependencies"
-python3 -m pip install --upgrade pip
-python3 -m pip install \
+"$ROOT_DIR/.venv/bin/python" -m pip install --upgrade pip
+"$ROOT_DIR/.venv/bin/pip" install \
   pytest \
   pytest-asyncio \
   pydantic \
@@ -36,7 +39,7 @@ python3 -m pip install \
   pip-audit
 
 echo " -> cross-impl requirements"
-python3 -m pip install -r "$ROOT_DIR/tests/cross-impl/requirements.txt"
+"$ROOT_DIR/.venv/bin/pip" install -r "$ROOT_DIR/tests/cross-impl/requirements.txt"
 
 echo ""
 echo "==> Bootstrap completed successfully"


### PR DESCRIPTION
This PR updates `scripts/bootstrap.sh` to install Python test dependencies safely into a local virtual environment (`.venv`) rather than relying on the globally installed Python environment similarly how `realworld-simulation` install:agent command does.

### Why?
Previously, `bootstrap.sh` ran `python3 -m pip install` globally, which can alter developer machines' global packages causing cross-project conflicts and potentially breaking system policies

### Changes Made
- Added a check to create a `.venv` folder in the project root if it doesn't already exist.
- Updated `pip install` commands for Python test dependencies and `cross-impl` to explicitly use the binaries from the `.venv` directory (`$ROOT_DIR/.venv/bin/pip`).

### How to Test
1. Check out this branch.
2. Ensure you optionally clear your existing global packages or test on a clean slate.
3. Run `bash scripts/bootstrap.sh`
4. Confirm that a `.venv` directory is created in the project root.
5. Verify that running tests via `bash test.sh` works correctly and hits the newly provisioned virtual environment.