### PR TITLE
Chore/add env example

### DIFF
--- a/examples/cross-impl/.env.example
+++ b/examples/cross-impl/.env.example
@@ -1,0 +1,5 @@
+# Node.js EEP Publisher URL
+NODE_PUBLISHER_URL=http://localhost:3001
+
+# Python EEP Publisher URL
+PYTHON_PUBLISHER_URL=http://localhost:8001

--- a/examples/cross-impl/README.md
+++ b/examples/cross-impl/README.md
@@ -24,9 +24,20 @@ pip install httpx pytest fastapi uvicorn
 docker compose up
 ```
 
+## Configuration
+
+```bash
+# Copy the environment template and configure URLs
+cp .env.example .env
+# Edit .env to set your publisher and subscriber URLs if different from defaults
+```
+
 ## Running the tests
 
 ```bash
+# First, configure environment:
+cp .env.example .env
+
 # Option 1: Shell script (local)
 bash test-interop.sh
 

--- a/examples/cross-impl/test_cross_impl.py
+++ b/examples/cross-impl/test_cross_impl.py
@@ -16,8 +16,6 @@ Usage:
 Environment variables:
     NODE_PUBLISHER_URL   (default: http://localhost:3001)
     PYTHON_PUBLISHER_URL (default: http://localhost:8001)
-    NODE_SUBSCRIBER_URL  (default: http://localhost:3002)
-    PYTHON_SUBSCRIBER_URL (default: http://localhost:8002)
 """
 import os
 import json

--- a/examples/langgraph-eep-agent/.env.example
+++ b/examples/langgraph-eep-agent/.env.example
@@ -1,0 +1,5 @@
+# EEP Publisher Target
+EEP_TARGET=http://localhost:3100
+
+# Anthropic API Key for Claude
+ANTHROPIC_API_KEY=sk-ant-your-api-key-here

--- a/examples/node-express-subscriber/.env.example
+++ b/examples/node-express-subscriber/.env.example
@@ -1,0 +1,11 @@
+# EEP Platform Configuration
+EEP_PLATFORM_URL=https://api.example.com
+
+# API Authentication
+EEP_API_KEY=your-api-key-here
+
+# Webhook HMAC Secret
+WEBHOOK_SECRET=your-webhook-secret-here
+
+# Server Port Configuration
+PORT=3001

--- a/examples/python-fastapi-subscriber/.env.example
+++ b/examples/python-fastapi-subscriber/.env.example
@@ -1,0 +1,8 @@
+# EEP Platform Configuration
+EEP_PLATFORM_URL=https://api.example.com
+
+# API Authentication
+EEP_API_KEY=your-api-key-here
+
+# Webhook HMAC Secret
+WEBHOOK_SECRET=your-webhook-secret-here


### PR DESCRIPTION
This pull request introduces example `.env.example` files and updates documentation to clarify environment variable configuration for several cross-implementation and example projects. These changes help standardize environment setup and make it easier for users to configure and run the projects.

**Environment variable template additions:**

* Added `.env.example` files to `examples/cross-impl`, `examples/langgraph-eep-agent`, `examples/node-express-subscriber`, and `examples/python-fastapi-subscriber`, specifying required environment variables such as publisher/subscriber URLs, API keys, and secrets. [[1]](diffhunk://#diff-0cea8895a9cbefc1b686e8835d6cb23910b4db23b46c2b56b5db34732fc4a820R1-R5) [[2]](diffhunk://#diff-043de253f2acc27bc151c4ed1bd7cfcdb2ec903a5123319ebb86510bb56c3c2cR1-R5) [[3]](diffhunk://#diff-c39fcf8aefc2c9a337037f3758826400317996a2be2d20c17f21d591f12f16a6R1-R11) [[4]](diffhunk://#diff-7dfcec0bfd6f73363be69ea64696219570af565fbd00a435b800dfbf12666888R1-R8)

**Documentation improvements:**

* Updated `README.md` in `examples/cross-impl` to include instructions for copying and editing the `.env.example` file for configuration.
* Updated `test_cross_impl.py` docstring to remove references to subscriber URLs, reflecting the new configuration approach.