### PR TITLE
docs(discovery): add crosswalk v1 guide and fixtures (#27)

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,9 @@ EEP is the contract for **agent ↔ entity** engagement: discovery, realtime str
 | **A2A** | Agent collaboration | agent ↔ agent | delegation and lifecycle |
 | **ANP** | Decentralized agent networking | agent ↔ agent | DID-centric coordination |
 
-See [eep-positioning-complementary.md](./docs/guides/eep-positioning-complementary.md) for a short comparison.
+See [eep-positioning-complementary.md](./docs/guides/eep-positioning-complementary.md) for a short comparison and
+[discovery-crosswalk-v1.md](./docs/guides/discovery-crosswalk-v1.md) for a copy-paste recipe that co-locates EEP,
+A2A Agent Card, MCP discovery and `llms.txt` on a single origin without conflict.
 
 ## Quick start
 

--- a/docs/guides/discovery-crosswalk-v1.md
+++ b/docs/guides/discovery-crosswalk-v1.md
@@ -1,0 +1,211 @@
+# Discovery crosswalk v1
+
+> **Informative — non-normative.** This guide documents how a single agentic
+> publisher can co-locate EEP, A2A, MCP and `llms.txt` discovery surfaces on
+> one origin without conflict. It does not change the EEP v0.1 specification.
+>
+> Tracks issue [#27](https://github.com/eep-dev/EEP/issues/27).
+
+## Why a crosswalk
+
+Agentic publishers today face **discovery sprawl**: the same domain is expected
+to expose multiple machine-readable surfaces — EEP at `/.well-known/eep.json`,
+A2A at `/.well-known/agent.json` (Agent Card), the emerging MCP discovery doc at
+`/.well-known/mcp.json`, optional DNS `_agent` bootstrap hints (AID), and the
+agent-readable corpus at `/llms.txt`.
+
+Without a documented crosswalk, integrators assume these protocols **compete,
+duplicate URLs, or contradict** each other. They do not. Each one solves a
+different layer; EEP is one of them. This guide shows the recipe.
+
+## Surface map
+
+| Surface | URL convention | Purpose | EEP relationship |
+|---------|----------------|---------|------------------|
+| **EEP manifest** | `/.well-known/eep.json` | Entity engagement — discovery, realtime streams, gates, payment-aware access | The EEP surface itself ([SPEC §12](../current/SPECIFICATION.md)) |
+| **A2A Agent Card** | `/.well-known/agent.json` | Agent-to-agent task delegation lifecycle | Complementary — carries the `x-eep` extension ([SPEC §12.2](../current/SPECIFICATION.md)) |
+| **MCP discovery** | `/.well-known/mcp.json` *(informative; tracks [modelcontextprotocol#1054](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1054))* | Tool / resource invocation for model runtimes | Complementary — MCP wraps tools, EEP publishes entity events |
+| **DNS `_agent` TXT** | `_agent.<domain>` (AID) | Bootstrap hint pointing at the well-known docs | Optional; EEP also defines `_eep.<domain>` in [SPEC §12.5](../current/SPECIFICATION.md) |
+| **`llms.txt`** | `/llms.txt` | Curated corpus for retrieval-oriented agents | Complementary — link the manifests above from it |
+
+See also the protocol-scope tables in
+[eep-positioning-complementary.md](./eep-positioning-complementary.md) and
+[protocol-positioning-matrix.md](./protocol-positioning-matrix.md). The
+short pitch stays the same: *MCP connects agents to tools; A2A connects agents
+to agents; EEP connects subscribers to entity state.*
+
+## URL layout convention
+
+Use **one HTTPS origin** and put every machine-readable surface under
+`/.well-known/*` (or, for `llms.txt`, at the document root). No rewrites or
+path prefixes required.
+
+```
+https://crosswalk.example/
+├── .well-known/
+│   ├── eep.json          ← EEP manifest        (normative; schemas/v0.1/eep-manifest.json)
+│   ├── agent.json        ← A2A Agent Card      (A2A v0.3)
+│   └── mcp.json          ← MCP discovery       (informative)
+├── llms.txt              ← curated corpus
+└── eep/                  ← EEP runtime endpoints (subscribe, stream, gates, ...)
+```
+
+DNS records sit on the side; they are optional bootstrap hints and never the
+source of truth for the manifest content.
+
+## Minimal JSON examples
+
+All four files below are also available offline as a fixture bundle:
+[`tests/conformance-fixtures/discovery/crosswalk-host/`](../../tests/conformance-fixtures/discovery/crosswalk-host/).
+
+### `/.well-known/eep.json`
+
+Subset of the SPEC §12.3 example. MUST validate against
+[`schemas/v0.1/eep-manifest.json`](../../schemas/v0.1/eep-manifest.json).
+
+```json
+{
+  "did": "did:web:crosswalk.example",
+  "eep_version": "0.1",
+  "layers": {
+    "layer1": "https://crosswalk.example/eep",
+    "layer2_sse": "https://crosswalk.example/eep/stream",
+    "layer2_webhook": "https://crosswalk.example/eep/subscribe",
+    "layer3_ws": "wss://crosswalk.example/eep/pulse"
+  },
+  "supported_content_types": ["application/json", "text/markdown", "text/toon"],
+  "pqc_ready": false,
+  "x402_enabled": true
+}
+```
+
+### `/.well-known/agent.json` (A2A v0.3 Agent Card)
+
+Carries the `x-eep` extension from SPEC §12.2 so an ANP-aware client can pivot
+from the agent card straight into the EEP stream.
+
+```json
+{
+  "schema_version": "0.3.0",
+  "name": "crosswalk-example",
+  "url": "https://crosswalk.example/a2a",
+  "version": "1.0.0",
+  "capabilities": { "streaming": true, "push_notifications": true },
+  "x-eep": {
+    "subscribe_url": "https://crosswalk.example/eep/subscribe",
+    "stream_url": "https://crosswalk.example/eep/stream",
+    "source_did": "did:web:crosswalk.example",
+    "supported_events": ["com.example.entity.*"],
+    "anp_compatible": true
+  }
+}
+```
+
+### `/.well-known/mcp.json` (informative)
+
+The MCP well-known discovery shape is still in proposal — see
+[modelcontextprotocol#1054](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1054).
+The shape below mirrors that draft and adds a `related` block so clients can
+hop between surfaces; field names may change as the upstream PR lands.
+
+```json
+{
+  "schema_version": "draft-0",
+  "servers": [
+    { "name": "crosswalk-tools", "transport": "streamable-http",
+      "url": "https://crosswalk.example/mcp" }
+  ],
+  "related": {
+    "eep_manifest": "https://crosswalk.example/.well-known/eep.json",
+    "agent_card":   "https://crosswalk.example/.well-known/agent.json"
+  }
+}
+```
+
+### DNS TXT (informative)
+
+```
+_agent.crosswalk.example.  IN  TXT  "v=aid1; eep=https://crosswalk.example/.well-known/eep.json; a2a=https://crosswalk.example/.well-known/agent.json; mcp=https://crosswalk.example/.well-known/mcp.json"
+_eep.crosswalk.example.    IN  TXT  "v=eep1; manifest=https://crosswalk.example/.well-known/eep.json"
+```
+
+The `_eep.<domain>` form is defined normatively in
+[SPEC §12.5](../current/SPECIFICATION.md). `_agent.<domain>` is informative; an
+EEP client SHOULD fall back to HTTP `/.well-known/*` probing if it is absent.
+
+### `/llms.txt`
+
+```markdown
+# Crosswalk Example
+
+> Single-origin host exposing EEP, A2A, MCP and llms.txt.
+
+## Machine-readable surfaces
+- [EEP manifest](https://crosswalk.example/.well-known/eep.json)
+- [A2A Agent Card](https://crosswalk.example/.well-known/agent.json)
+- [MCP discovery](https://crosswalk.example/.well-known/mcp.json)
+```
+
+## Combined `Link` response header
+
+Any entity resolution response can advertise all surfaces in a single round
+trip. This aligns with the existing EEP `Link` examples in
+[SPEC §12.1](../current/SPECIFICATION.md).
+
+```http
+HTTP/1.1 200 OK
+Content-Type: application/json
+Link: </.well-known/eep.json>; rel="eep-manifest"; type="application/json"
+Link: </.well-known/agent.json>; rel="agent-card"; type="application/json"
+Link: </.well-known/mcp.json>; rel="mcp-discovery"; type="application/json"
+Link: <https://crosswalk.example/eep/subscribe>; rel="subscribe"; type="application/json"
+Link: <https://crosswalk.example/eep/stream?source=crosswalk.example>; rel="monitor"
+Link: </llms.txt>; rel="llms"; type="text/plain"
+```
+
+## When to use which (decision tree)
+
+```
+Is the question "what changed about this entity and how do I follow it?"
+   ├─ yes → EEP                                  (/.well-known/eep.json)
+   └─ no  → Is it "call a tool / use a resource"?
+               ├─ yes → MCP                       (/.well-known/mcp.json)
+               └─ no  → Is it "delegate a task to another agent"?
+                           ├─ yes → A2A           (/.well-known/agent.json)
+                           └─ no  → "feed an LLM curated context"
+                                       → /llms.txt
+```
+
+The crosswalk does not pick one for you; it makes the question answerable
+from a single origin in a single round trip.
+
+## Conformance and fixtures
+
+The companion fixture bundle at
+[`tests/conformance-fixtures/discovery/crosswalk-host/`](../../tests/conformance-fixtures/discovery/crosswalk-host/)
+contains the example files above as bytes-on-disk. The reference test
+[`packages/@eep-dev/discovery/src/crosswalk-fixture.test.ts`](../../packages/@eep-dev/discovery/src/crosswalk-fixture.test.ts)
+loads `eep.json` through `validateManifest()` and confirms every sibling file
+is present.
+
+A conformance-cli probe that logs PASS when a target host serves both
+`/.well-known/eep.json` and `/.well-known/agent.json` is tracked as a follow-up
+to this guide; the absence of sibling surfaces is **not** an EEP conformance
+failure.
+
+## Non-goals (v1)
+
+- **No normative spec changes.** This is an informative guide; EEIP can follow
+  if a normative surface map is later agreed.
+- **No global agent directory or marketplace.**
+- **Not a replacement** for MCP, A2A or ANP discovery; their respective specs
+  remain authoritative for their own surfaces.
+
+## References
+
+- [SPEC §12 Discovery](../current/SPECIFICATION.md) — primary normative source for `/.well-known/eep.json`, `Link` headers and DNS TXT.
+- [eep-positioning-complementary.md](./eep-positioning-complementary.md) — one-page comparison of EEP vs MCP / A2A / ANP.
+- [protocol-positioning-matrix.md](./protocol-positioning-matrix.md) — scope matrix.
+- [strategy/unmet-needs-map.md](../strategy/unmet-needs-map.md) — why the crosswalk lands here.
+- [A2A Agent Card](https://github.com/a2aproject/A2A) — upstream spec.
+- [MCP well-known discussion (PR #1054)](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1054) — informative shape source.

--- a/docs/guides/eep-positioning-complementary.md
+++ b/docs/guides/eep-positioning-complementary.md
@@ -11,3 +11,5 @@ It is **not** a replacement for:
 | **ANP** | Decentralized agent networking | Complementary — EEP’s discovery and DID usage can align with agent network identity patterns. |
 
 **One-sentence pitch:** *MCP connects agents to tools; EEP connects subscribers to entity state changes with standard discovery and delivery semantics.*
+
+**See also:** [discovery-crosswalk-v1.md](./discovery-crosswalk-v1.md) — single-origin recipe co-locating `/.well-known/eep.json`, `/.well-known/agent.json` (A2A) and `/.well-known/mcp.json` without conflict.

--- a/packages/@eep-dev/discovery/src/crosswalk-fixture.test.ts
+++ b/packages/@eep-dev/discovery/src/crosswalk-fixture.test.ts
@@ -1,0 +1,66 @@
+/**
+ * Discovery crosswalk v1 — fixture conformance test.
+ *
+ * Loads the offline crosswalk-host fixture bundle and asserts:
+ *   1. eep.json still validates against `validateManifest()` even though
+ *      sibling well-known files (agent.json, mcp.json) live next to it.
+ *   2. Every file the guide promises to ship in the bundle is on disk.
+ *
+ * Backs issue #27 acceptance criterion: "Fixture directory present; at least
+ * one Vitest/pytest asserts EEP manifest validation against crosswalk bundle".
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { validateManifest } from './manifest';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const FIXTURE_DIR = resolve(
+    __dirname,
+    '../../../..',
+    'tests/conformance-fixtures/discovery/crosswalk-host',
+);
+
+describe('discovery crosswalk-host fixture bundle', () => {
+    it('eep.json validates against validateManifest()', () => {
+        const raw = readFileSync(resolve(FIXTURE_DIR, 'eep.json'), 'utf8');
+        const result = validateManifest(JSON.parse(raw));
+        expect(result.valid).toBe(true);
+        expect(result.errors).toHaveLength(0);
+        expect(result.manifest?.did).toBe('did:web:crosswalk.example');
+    });
+
+    it('agent.json carries the x-eep extension pointing at the same origin', () => {
+        const card = JSON.parse(readFileSync(resolve(FIXTURE_DIR, 'agent.json'), 'utf8'));
+        expect(card['x-eep']).toBeDefined();
+        expect(card['x-eep'].source_did).toBe('did:web:crosswalk.example');
+        expect(card['x-eep'].subscribe_url).toMatch(/^https:\/\/crosswalk\.example\//);
+        expect(card['x-eep'].stream_url).toMatch(/^https:\/\/crosswalk\.example\//);
+    });
+
+    it('expected.json summarises the bundle correctly', () => {
+        const expected = JSON.parse(readFileSync(resolve(FIXTURE_DIR, 'expected.json'), 'utf8'));
+        expect(expected.eep_manifest_valid).toBe(true);
+        expect(expected.co_located_surfaces).toEqual(
+            expect.arrayContaining(['eep', 'a2a', 'mcp', 'llms']),
+        );
+    });
+
+    it('every file the crosswalk guide promises is present', () => {
+        const required = [
+            'eep.json',
+            'agent.json',
+            'mcp.json',
+            'llms.txt',
+            'link-header.http',
+            'dns-txt.txt',
+            'expected.json',
+            'README.md',
+        ];
+        for (const name of required) {
+            expect(existsSync(resolve(FIXTURE_DIR, name))).toBe(true);
+        }
+    });
+});

--- a/tests/conformance-fixtures/README.md
+++ b/tests/conformance-fixtures/README.md
@@ -32,6 +32,10 @@ Every fixture directory contains either:
   (raw signed bytes), `headers.json` (request headers including
   `webhook-id` / `webhook-timestamp` / `webhook-signature`),
   `secret.txt` (the test secret), and `expected.json` (`{"valid": true|false, "reason": ...}`).
+- **A static bundle** (`shape: "bundle"`) — a directory of static files served
+  by a single host (e.g. `discovery/crosswalk-host/`). Used for informative
+  fixtures where multiple files coexist; `expected.json` summarises what a
+  validator should see.
 
 Some fixtures are deliberately *invalid* — they encode bytes that
 implementations MUST reject. The expected outcome makes the rejection

--- a/tests/conformance-fixtures/discovery/crosswalk-host/README.md
+++ b/tests/conformance-fixtures/discovery/crosswalk-host/README.md
@@ -1,0 +1,34 @@
+# Discovery crosswalk — single-origin bundle
+
+Offline fixture bundle backing the
+[Discovery Crosswalk v1 guide](../../../../docs/guides/discovery-crosswalk-v1.md).
+
+Every file in this directory pretends to be served from the **same HTTPS origin**,
+`https://crosswalk.example`. The point is to show that an agentic publisher can
+expose EEP, A2A, MCP and `llms.txt` side by side without any of them colliding on
+URLs or contradicting each other.
+
+## Contents
+
+| File | Served at | Purpose |
+|------|-----------|---------|
+| `eep.json` | `/.well-known/eep.json` | EEP manifest. MUST validate against `schemas/v0.1/eep-manifest.json`. |
+| `agent.json` | `/.well-known/agent.json` | A2A v0.3 Agent Card. Carries the `x-eep` extension from SPEC §12.2. |
+| `mcp.json` | `/.well-known/mcp.json` | Informative MCP well-known discovery doc; tracks [modelcontextprotocol#1054](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/1054). |
+| `llms.txt` | `/llms.txt` | Curated corpus pointing at the three manifests. |
+| `link-header.http` | example HTTP response | Combined `Link:` header response demonstrating all `rel`s coexisting. |
+| `dns-txt.txt` | DNS TXT records | Informative `_agent` (AID) and `_eep` (SPEC §12.5) bootstrap hints. |
+| `expected.json` | (assertion) | Machine-readable summary of what a validator should see. |
+
+## How to consume
+
+The reference TypeScript test
+[`crosswalk-fixture.test.ts`](../../../../packages/@eep-dev/discovery/src/crosswalk-fixture.test.ts)
+loads `eep.json` through `@eep-dev/discovery`'s `validateManifest()` and asserts
+that all sibling files are present. Implementations in other languages can do the
+same — these are just bytes on disk.
+
+## Status
+
+Informative. No normative schemas change. See the guide for non-goals and the
+`Discovery Crosswalk v1` section in `tests/conformance-fixtures/manifest.json`.

--- a/tests/conformance-fixtures/discovery/crosswalk-host/agent.json
+++ b/tests/conformance-fixtures/discovery/crosswalk-host/agent.json
@@ -1,0 +1,37 @@
+{
+  "schema_version": "0.3.0",
+  "name": "crosswalk-example",
+  "description": "Example A2A Agent Card co-located with EEP, MCP and llms.txt on a single origin.",
+  "url": "https://crosswalk.example/a2a",
+  "provider": {
+    "organization": "Crosswalk Example, Inc.",
+    "url": "https://crosswalk.example"
+  },
+  "version": "1.0.0",
+  "documentation_url": "https://crosswalk.example/docs",
+  "capabilities": {
+    "streaming": true,
+    "push_notifications": true,
+    "state_transition_history": false
+  },
+  "default_input_modes": ["application/json", "text/plain"],
+  "default_output_modes": ["application/json", "text/markdown"],
+  "skills": [
+    {
+      "id": "summarize-entity",
+      "name": "Summarize entity",
+      "description": "Returns a short summary of the entity behind this card.",
+      "input_modes": ["text/plain"],
+      "output_modes": ["text/markdown"]
+    }
+  ],
+  "x-eep": {
+    "subscribe_url": "https://crosswalk.example/eep/subscribe",
+    "stream_url": "https://crosswalk.example/eep/stream",
+    "source_did": "did:web:crosswalk.example",
+    "supported_events": ["com.example.entity.*", "com.example.trust.*"],
+    "anp_compatible": true,
+    "dpv_purpose": "https://w3id.org/dpv#ServiceProvision",
+    "dpv_retention": "https://w3id.org/dpv#TemporalDuration"
+  }
+}

--- a/tests/conformance-fixtures/discovery/crosswalk-host/dns-txt.txt
+++ b/tests/conformance-fixtures/discovery/crosswalk-host/dns-txt.txt
@@ -1,0 +1,7 @@
+; Informative DNS TXT bootstrap (AID — Agent Interface Discovery).
+; Not normative; clients SHOULD fall back to HTTP /.well-known/* probing.
+
+_agent.crosswalk.example.   IN  TXT  "v=aid1; eep=https://crosswalk.example/.well-known/eep.json; a2a=https://crosswalk.example/.well-known/agent.json; mcp=https://crosswalk.example/.well-known/mcp.json"
+
+; SPEC §12.5 also defines a TXT form scoped to EEP only:
+_eep.crosswalk.example.     IN  TXT  "v=eep1; manifest=https://crosswalk.example/.well-known/eep.json"

--- a/tests/conformance-fixtures/discovery/crosswalk-host/eep.json
+++ b/tests/conformance-fixtures/discovery/crosswalk-host/eep.json
@@ -1,0 +1,28 @@
+{
+  "did": "did:web:crosswalk.example",
+  "eep_version": "0.1",
+  "eep_versions": ["0.1"],
+  "preferred_version": "0.1",
+  "layers": {
+    "layer1": "https://crosswalk.example/eep",
+    "layer2_sse": "https://crosswalk.example/eep/stream",
+    "layer2_webhook": "https://crosswalk.example/eep/subscribe",
+    "layer3_ws": "wss://crosswalk.example/eep/pulse"
+  },
+  "supported_content_types": [
+    "application/json",
+    "text/markdown",
+    "text/toon"
+  ],
+  "gates_url": "https://crosswalk.example/eep/gates/did:web:crosswalk.example",
+  "services_url": "https://crosswalk.example/eep/services/did:web:crosswalk.example",
+  "capabilities_query_url": "https://crosswalk.example/.well-known/eep.json/capabilities",
+  "pqc_ready": false,
+  "x402_enabled": true,
+  "x402": {
+    "facilitator_url": "https://x402.org/facilitator",
+    "payment_rails": ["x402/usdc"],
+    "network": "base"
+  },
+  "updated_at": "2026-05-21T00:00:00Z"
+}

--- a/tests/conformance-fixtures/discovery/crosswalk-host/expected.json
+++ b/tests/conformance-fixtures/discovery/crosswalk-host/expected.json
@@ -1,0 +1,7 @@
+{
+  "eep_manifest_valid": true,
+  "co_located_surfaces": ["eep", "a2a", "mcp", "llms"],
+  "origin": "https://crosswalk.example",
+  "source_did": "did:web:crosswalk.example",
+  "notes": "Informative bundle for Discovery Crosswalk v1. eep.json MUST validate against schemas/v0.1/eep-manifest.json. agent.json and mcp.json are informative — their schemas track upstream A2A v0.3 and the MCP well-known discovery proposal respectively."
+}

--- a/tests/conformance-fixtures/discovery/crosswalk-host/link-header.http
+++ b/tests/conformance-fixtures/discovery/crosswalk-host/link-header.http
@@ -1,0 +1,8 @@
+HTTP/1.1 200 OK
+Content-Type: application/json
+Link: </.well-known/eep.json>; rel="eep-manifest"; type="application/json"
+Link: </.well-known/agent.json>; rel="agent-card"; type="application/json"
+Link: </.well-known/mcp.json>; rel="mcp-discovery"; type="application/json"
+Link: <https://crosswalk.example/eep/subscribe>; rel="subscribe"; type="application/json"
+Link: <https://crosswalk.example/eep/stream?source=crosswalk.example>; rel="monitor"
+Link: </llms.txt>; rel="llms"; type="text/plain"

--- a/tests/conformance-fixtures/discovery/crosswalk-host/llms.txt
+++ b/tests/conformance-fixtures/discovery/crosswalk-host/llms.txt
@@ -1,0 +1,15 @@
+# Crosswalk Example
+
+> Example single-origin host that co-locates EEP, A2A Agent Card, MCP and llms.txt.
+> Intended as offline reference for the Discovery Crosswalk v1 guide.
+
+## Machine-readable surfaces
+
+- [EEP manifest](https://crosswalk.example/.well-known/eep.json): entity engagement (discovery, streams, gates).
+- [A2A Agent Card](https://crosswalk.example/.well-known/agent.json): agent-to-agent task delegation.
+- [MCP discovery](https://crosswalk.example/.well-known/mcp.json): tool / resource invocation (informative).
+
+## Optional
+
+- DNS `TXT _agent.crosswalk.example` — informative bootstrap hint (AID).
+- Combined `Link:` response header — see `link-header.http` in this bundle.

--- a/tests/conformance-fixtures/discovery/crosswalk-host/mcp.json
+++ b/tests/conformance-fixtures/discovery/crosswalk-host/mcp.json
@@ -1,0 +1,22 @@
+{
+  "$comment": "Informative example — tracks the MCP well-known discovery proposal in modelcontextprotocol/modelcontextprotocol#1054. Field names may change as the upstream PR lands.",
+  "schema_version": "draft-0",
+  "name": "crosswalk-example-mcp",
+  "description": "Tool surface co-located with EEP and A2A on the same origin.",
+  "servers": [
+    {
+      "name": "crosswalk-tools",
+      "transport": "streamable-http",
+      "url": "https://crosswalk.example/mcp",
+      "auth": {
+        "scheme": "bearer",
+        "token_url": "https://crosswalk.example/oauth/token"
+      }
+    }
+  ],
+  "related": {
+    "eep_manifest": "https://crosswalk.example/.well-known/eep.json",
+    "agent_card": "https://crosswalk.example/.well-known/agent.json",
+    "llms_txt": "https://crosswalk.example/llms.txt"
+  }
+}

--- a/tests/conformance-fixtures/manifest.json
+++ b/tests/conformance-fixtures/manifest.json
@@ -158,6 +158,16 @@
       "expected": "subscription/ssrf-private-ip-rejected.expected.json",
       "shape": "json-pair",
       "asserts_valid": false
+    },
+    {
+      "id": "discovery-crosswalk-host-bundle",
+      "category": "discovery",
+      "tier": "Informative",
+      "spec_section": "§12 Discovery (informative crosswalk)",
+      "path": "discovery/crosswalk-host",
+      "expected": "discovery/crosswalk-host/expected.json",
+      "shape": "bundle",
+      "asserts_valid": true
     }
   ]
 }


### PR DESCRIPTION
## Summary

Closes #27. Ships **Discovery Crosswalk v1** — an informative single-origin recipe
that co-locates EEP, A2A Agent Card, MCP discovery and \`llms.txt\` without
conflict, plus an offline fixture bundle and a vitest test that drives
\`@eep-dev/discovery\`'s \`validateManifest()\` against it.

- 📄 New guide: \`docs/guides/discovery-crosswalk-v1.md\`
- 📦 New fixture bundle: \`tests/conformance-fixtures/discovery/crosswalk-host/\`
- 🧪 New test: \`packages/@eep-dev/discovery/src/crosswalk-fixture.test.ts\`
- 🔗 Wired from \`README.md\` (Protocol positioning) and
  \`docs/guides/eep-positioning-complementary.md\` (See also)
- 🧾 Fixtures index updated; new \`bundle\` shape documented in
  \`tests/conformance-fixtures/README.md\`

No normative spec changes. No schema changes. v0.1 untouched.

> **Note:** issue body cites "SPEC §4 (Discovery)", but the current Discovery
> section is **§12**. The guide references §12 throughout.

## Acceptance criteria (from #27)

- [x] Guide merged with all four well-known examples and a single-host diagram
- [x] Fixture directory present; vitest asserts EEP manifest validation against the bundle
- [x] README links to the guide
- [x] No contradiction with \`docs/current/SPECIFICATION.md\` §12 Discovery
- [x] English only; no breaking changes to v0.1 schemas

## Deferred (follow-up)

- Compliance-cli probe that PASSes when a target host serves both \`eep.json\`
  and \`agent.json\` (called out in the issue as "optional stretch").
- Subsection on [eep.dev](https://eep.dev) — separate PR in \`eep-dev/eep-site\`.

## Test plan

- [x] \`cd packages/@eep-dev/discovery && npm test\` — 42/42 passing
  (4 new crosswalk-fixture tests + 38 pre-existing).
- [x] \`npm run test:coverage\` matches \`main\` (97.33% — unchanged).
- [x] Each new \`*.json\` fixture parses cleanly (validated via node).
- [x] \`tests/conformance-fixtures/manifest.json\` still parses after the
      append.

🤖 Generated with [Claude Code](https://claude.com/claude-code)