### PR TITLE
fix(validator): inspect IPv6 (AAAA) records in the SSRF check

### DIFF
--- a/packages/@eep-dev/validator/src/index.test.ts
+++ b/packages/@eep-dev/validator/src/index.test.ts
@@ -2,8 +2,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { validateSSRF, SSRFError, validateEventTypePattern, matchesEventType, matchesAnyPattern } from './index';
 
 // Mock DNS resolution for SSRF tests — vi.hoisted ensures the fn is available when vi.mock is hoisted
-const { mockDnsResolve } = vi.hoisted(() => ({ mockDnsResolve: vi.fn() }));
-vi.mock('dns/promises', () => ({ resolve: mockDnsResolve }));
+const { mockResolve4, mockResolve6 } = vi.hoisted(() => ({ mockResolve4: vi.fn(), mockResolve6: vi.fn() }));
+vi.mock('dns/promises', () => ({ resolve4: mockResolve4, resolve6: mockResolve6 }));
 
 describe('@eep-dev/validator', () => {
 
@@ -156,93 +156,111 @@ describe('@eep-dev/validator', () => {
 
     describe('validateSSRF — DNS-mocked private IP ranges', () => {
         beforeEach(() => {
-            mockDnsResolve.mockReset();
+            mockResolve4.mockReset();
+            mockResolve6.mockReset();
+            // Default: a host resolves to nothing in either family unless a test says so.
+            mockResolve4.mockResolvedValue([]);
+            mockResolve6.mockResolvedValue([]);
         });
 
         it('should reject 10.x.x.x (Private class A)', async () => {
-            mockDnsResolve.mockResolvedValueOnce(['10.0.0.1']);
+            mockResolve4.mockResolvedValueOnce(['10.0.0.1']);
             await expect(validateSSRF('https://evil.example.com/hook')).rejects.toThrow(SSRFError);
         });
 
         it('should reject 172.16.x.x (Private class B)', async () => {
-            mockDnsResolve.mockResolvedValueOnce(['172.16.5.10']);
+            mockResolve4.mockResolvedValueOnce(['172.16.5.10']);
             await expect(validateSSRF('https://evil.example.com/hook')).rejects.toThrow(SSRFError);
         });
 
         it('should reject 192.168.x.x (Private class C)', async () => {
-            mockDnsResolve.mockResolvedValueOnce(['192.168.1.1']);
+            mockResolve4.mockResolvedValueOnce(['192.168.1.1']);
             await expect(validateSSRF('https://evil.example.com/hook')).rejects.toThrow(SSRFError);
         });
 
         it('should reject 169.254.169.254 (AWS metadata)', async () => {
-            mockDnsResolve.mockResolvedValueOnce(['169.254.169.254']);
+            mockResolve4.mockResolvedValueOnce(['169.254.169.254']);
             await expect(validateSSRF('https://evil.example.com/hook')).rejects.toThrow('Link-local');
         });
 
         it('should reject 127.0.0.1 (loopback via DNS)', async () => {
-            mockDnsResolve.mockResolvedValueOnce(['127.0.0.1']);
+            mockResolve4.mockResolvedValueOnce(['127.0.0.1']);
             await expect(validateSSRF('https://safe-looking.example.com')).rejects.toThrow('loopback');
         });
 
         it('should accept public IP addresses', async () => {
-            mockDnsResolve.mockResolvedValueOnce(['93.184.216.34']);
+            mockResolve4.mockResolvedValueOnce(['93.184.216.34']);
             await expect(validateSSRF('https://example.com/webhook')).resolves.toBeUndefined();
         });
 
         it('should reject multicast range (224.x)', async () => {
-            mockDnsResolve.mockResolvedValueOnce(['224.0.0.1']);
+            mockResolve4.mockResolvedValueOnce(['224.0.0.1']);
             await expect(validateSSRF('https://evil.example.com')).rejects.toThrow('Multicast');
         });
 
         it('should reject 0.0.0.0/8 range', async () => {
-            mockDnsResolve.mockResolvedValueOnce(['0.0.0.1']);
+            mockResolve4.mockResolvedValueOnce(['0.0.0.1']);
             await expect(validateSSRF('https://evil.example.com')).rejects.toThrow('Reserved');
         });
 
-        it('should throw SSRFError when DNS resolution fails', async () => {
-            mockDnsResolve.mockRejectedValueOnce(new Error('ENOTFOUND'));
+        it('should reject a private IPv6 (AAAA) hidden behind a public IPv4 (A) — dual-stack bypass', async () => {
+            mockResolve4.mockResolvedValueOnce(['93.184.216.34']); // public decoy
+            mockResolve6.mockResolvedValueOnce(['fd00::1']);        // private ULA
+            await expect(validateSSRF('https://dual-stack.example.com'))
+                .rejects.toThrow('private/reserved');
+        });
+
+        it('should accept a public host that is IPv4-only (AAAA returns NODATA)', async () => {
+            mockResolve4.mockResolvedValueOnce(['93.184.216.34']);
+            mockResolve6.mockRejectedValueOnce(new Error('queryAaaa ENODATA example.com'));
+            await expect(validateSSRF('https://example.com/webhook')).resolves.toBeUndefined();
+        });
+
+        it('should throw SSRFError only when BOTH families fail to resolve', async () => {
+            mockResolve4.mockRejectedValueOnce(new Error('ENOTFOUND'));
+            mockResolve6.mockRejectedValueOnce(new Error('ENOTFOUND'));
             await expect(validateSSRF('https://nonexistent.example.invalid'))
                 .rejects.toThrow('DNS resolution failed');
         });
 
         it('should reject IPv6 unique-local addresses (fc00::)', async () => {
-            mockDnsResolve.mockResolvedValueOnce(['fc00::1']);
+            mockResolve6.mockResolvedValueOnce(['fc00::1']);
             await expect(validateSSRF('https://evil.example.com'))
                 .rejects.toThrow('private/reserved');
         });
 
         it('should reject IPv6 unique-local addresses in fd00::/8', async () => {
-            mockDnsResolve.mockResolvedValueOnce(['fd12::abcd']);
+            mockResolve6.mockResolvedValueOnce(['fd12::abcd']);
             await expect(validateSSRF('https://evil.example.com'))
                 .rejects.toThrow('private/reserved');
         });
 
         it('should reject IPv6 link-local addresses (fe80::/10)', async () => {
-            mockDnsResolve.mockResolvedValueOnce(['fe80::1']);
+            mockResolve6.mockResolvedValueOnce(['fe80::1']);
             await expect(validateSSRF('https://evil.example.com'))
                 .rejects.toThrow('private/reserved');
         });
 
         it('should reject IPv4-mapped IPv6 addresses (::ffff:192.168.x.x)', async () => {
-            mockDnsResolve.mockResolvedValueOnce(['::ffff:192.168.1.1']);
+            mockResolve6.mockResolvedValueOnce(['::ffff:192.168.1.1']);
             await expect(validateSSRF('https://evil.example.com'))
                 .rejects.toThrow(SSRFError);
         });
 
         it('should reject resolved IPv6 loopback ::1 via DNS', async () => {
-            mockDnsResolve.mockResolvedValueOnce(['::1']);
+            mockResolve6.mockResolvedValueOnce(['::1']);
             await expect(validateSSRF('https://evil.example.com'))
                 .rejects.toThrow('private/reserved');
         });
 
         it('should reject resolved IPv6 unspecified :: via DNS', async () => {
-            mockDnsResolve.mockResolvedValueOnce(['::']);
+            mockResolve6.mockResolvedValueOnce(['::']);
             await expect(validateSSRF('https://evil.example.com'))
                 .rejects.toThrow('private/reserved');
         });
 
         it('should accept public IPv6 documentation prefix (2001:db8::/32)', async () => {
-            mockDnsResolve.mockResolvedValueOnce(['2001:db8::1']);
+            mockResolve6.mockResolvedValueOnce(['2001:db8::1']);
             await expect(validateSSRF('https://example.com/webhook')).resolves.toBeUndefined();
         });
     });

--- a/packages/@eep-dev/validator/src/index.ts
+++ b/packages/@eep-dev/validator/src/index.ts
@@ -1,4 +1,4 @@
-import { resolve as dnsResolve } from 'dns/promises';
+import { resolve4, resolve6 } from 'dns/promises';
 
 /**
  * @eep-dev/validator
@@ -82,12 +82,23 @@ export async function validateSSRF(
         throw new SSRFError(`Blocked hostname: '${hostname}' resolves to localhost`);
     }
 
-    // 3. DNS resolution and IP validation
-    let resolvedAddresses: string[];
-    try {
-        resolvedAddresses = await dnsResolve(hostname);
-    } catch (error) {
-        throw new SSRFError(`DNS resolution failed for '${hostname}': ${(error as Error).message}`);
+    // 3. DNS resolution and IP validation.
+    //    Resolve BOTH address families: a host can present a public IPv4 (A) while
+    //    hiding a private IPv6 (AAAA) — or vice versa — and the OS resolver may then
+    //    connect over the unchecked family. Block if *any* resolved address is private;
+    //    only treat the host as unresolvable when *both* families fail.
+    const resolvedAddresses: string[] = [];
+    const resolutionErrors: string[] = [];
+    const settled = await Promise.allSettled([resolve4(hostname), resolve6(hostname)]);
+    for (const result of settled) {
+        if (result.status === 'fulfilled') {
+            resolvedAddresses.push(...result.value);
+        } else {
+            resolutionErrors.push((result.reason as Error).message);
+        }
+    }
+    if (resolvedAddresses.length === 0) {
+        throw new SSRFError(`DNS resolution failed for '${hostname}': ${resolutionErrors.join('; ')}`);
     }
 
     for (const address of resolvedAddresses) {

--- a/packages/@eep-dev/validator/src/security.test.ts
+++ b/packages/@eep-dev/validator/src/security.test.ts
@@ -1,13 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { validateSSRF, SSRFError, validateEventTypePattern } from './index';
 
-const { mockDnsResolve } = vi.hoisted(() => ({ mockDnsResolve: vi.fn() }));
-vi.mock('dns/promises', () => ({ resolve: mockDnsResolve }));
+const { mockResolve4, mockResolve6 } = vi.hoisted(() => ({
+    mockResolve4: vi.fn(),
+    mockResolve6: vi.fn(),
+}));
+vi.mock('dns/promises', () => ({ resolve4: mockResolve4, resolve6: mockResolve6 }));
 
 describe('Validator Security', () => {
 
     beforeEach(() => {
-        mockDnsResolve.mockReset();
+        mockResolve4.mockReset();
+        mockResolve6.mockReset();
+        // Default: a host resolves to nothing in either family unless a test says so.
+        mockResolve4.mockResolvedValue([]);
+        mockResolve6.mockResolvedValue([]);
     });
 
     describe('SSRF Prevention', () => {
@@ -17,29 +24,52 @@ describe('Validator Security', () => {
         });
 
         it('rejects private IP ranges (10.x, 172.16-31.x, 192.168.x)', async () => {
-            mockDnsResolve.mockResolvedValueOnce(['10.0.0.1']);
+            mockResolve4.mockResolvedValueOnce(['10.0.0.1']);
             await expect(validateSSRF('https://evil.com/hook')).rejects.toThrow('Private class A');
 
-            mockDnsResolve.mockResolvedValueOnce(['172.16.0.1']);
+            mockResolve4.mockResolvedValueOnce(['172.16.0.1']);
             await expect(validateSSRF('https://evil.com/hook')).rejects.toThrow('Private class B');
 
-            mockDnsResolve.mockResolvedValueOnce(['192.168.1.1']);
+            mockResolve4.mockResolvedValueOnce(['192.168.1.1']);
             await expect(validateSSRF('https://evil.com/hook')).rejects.toThrow('Private class C');
         });
 
-        it('rejects IPv6 mapped IPv4 addresses', async () => {
-            mockDnsResolve.mockResolvedValueOnce(['::ffff:127.0.0.1']);
+        it('rejects IPv6 mapped IPv4 addresses (AAAA family)', async () => {
+            mockResolve6.mockResolvedValueOnce(['::ffff:127.0.0.1']);
             await expect(validateSSRF('https://evil.com/hook')).rejects.toThrow(SSRFError);
 
-            mockDnsResolve.mockResolvedValueOnce(['::ffff:10.0.0.1']);
+            mockResolve6.mockResolvedValueOnce(['::ffff:10.0.0.1']);
             await expect(validateSSRF('https://evil.com/hook')).rejects.toThrow(SSRFError);
         });
 
-        it('rejects DNS rebinding attempts', async () => {
-            // First call resolves to public, simulating a TOCTOU DNS rebind
-            // The validator checks all resolved addresses; if any is private, it rejects.
-            mockDnsResolve.mockResolvedValueOnce(['93.184.216.34', '127.0.0.1']);
+        it('rejects a host that hides a private IPv6 (AAAA) behind a public IPv4 (dual-stack bypass)', async () => {
+            // Regression: the validator used to resolve A records only, so a private
+            // AAAA address was never inspected and the OS could connect over IPv6.
+            mockResolve4.mockResolvedValueOnce(['93.184.216.34']); // public decoy
+            mockResolve6.mockResolvedValueOnce(['fd00::1']);        // private ULA (fc00::/7)
+            await expect(validateSSRF('https://dual-stack.example.com/hook')).rejects.toThrow(SSRFError);
+        });
+
+        it('rejects an IPv6 link-local AAAA record', async () => {
+            mockResolve6.mockResolvedValueOnce(['fe80::1']);
+            await expect(validateSSRF('https://evil.com/hook')).rejects.toThrow('private/reserved');
+        });
+
+        it('allows a public host that is IPv4-only (AAAA returns NODATA)', async () => {
+            mockResolve4.mockResolvedValueOnce(['93.184.216.34']);
+            mockResolve6.mockRejectedValueOnce(new Error('queryAaaa ENODATA evil.com'));
+            await expect(validateSSRF('https://example.com/hook')).resolves.toBeUndefined();
+        });
+
+        it('rejects DNS rebinding attempts (any resolved address private)', async () => {
+            mockResolve4.mockResolvedValueOnce(['93.184.216.34', '127.0.0.1']);
             await expect(validateSSRF('https://rebind.example.com/hook')).rejects.toThrow(SSRFError);
+        });
+
+        it('reports a DNS failure only when BOTH families fail to resolve', async () => {
+            mockResolve4.mockRejectedValueOnce(new Error('queryA ENOTFOUND nope.invalid'));
+            mockResolve6.mockRejectedValueOnce(new Error('queryAaaa ENOTFOUND nope.invalid'));
+            await expect(validateSSRF('https://nope.invalid/hook')).rejects.toThrow('DNS resolution failed');
         });
 
         it('rejects URL-encoded bypass attempts', async () => {
@@ -56,12 +86,12 @@ describe('Validator Security', () => {
         });
 
         it('rejects link-local / AWS metadata IP 169.254.169.254', async () => {
-            mockDnsResolve.mockResolvedValueOnce(['169.254.169.254']);
+            mockResolve4.mockResolvedValueOnce(['169.254.169.254']);
             await expect(validateSSRF('https://evil.com/hook')).rejects.toThrow('Link-local');
         });
 
         it('rejects multicast range addresses', async () => {
-            mockDnsResolve.mockResolvedValueOnce(['224.0.0.1']);
+            mockResolve4.mockResolvedValueOnce(['224.0.0.1']);
             await expect(validateSSRF('https://evil.com/hook')).rejects.toThrow('Multicast');
         });
 
@@ -86,7 +116,7 @@ describe('Validator Security', () => {
         it('handles unicode normalization attacks', async () => {
             // Homoglyph: "ⅼocalhost" uses Unicode ⅼ (U+217C) instead of ASCII l
             // URL constructor should either reject or normalize this differently from 'localhost'
-            const homoglyphUrl = 'https://\u217Cocalhost/hook';
+            const homoglyphUrl = 'https://ⅼocalhost/hook';
             try {
                 await validateSSRF(homoglyphUrl);
                 // If it doesn't throw, it must have resolved to a public IP (DNS would fail)


### PR DESCRIPTION
## Problem
`validateSSRF` in `@eep-dev/validator` resolved only **A (IPv4)** records (`dns.resolve` defaults to A). A host that publishes a public A record while hiding a **private AAAA** (e.g. `::1` or an `fc00::/7` ULA) passed the check, after which the OS resolver could connect over the unvalidated IPv6 address. The IPv6 branch of `checkIPBlocked` was effectively dead in production, and the tests gave false confidence by mocking IPv6 responses that `dns.resolve` can never return.

## Fix
- Resolve **both** families via `resolve4` + `resolve6` (`Promise.allSettled`).
- Block if **any** resolved address is private; only report a DNS failure when **both** families fail, so IPv4-only / IPv6-only hosts still work.
- Brings the TS validator to parity with the Python validator (`getaddrinfo(AF_UNSPEC)`).

## Tests
- New regression test for the public-A / private-AAAA dual-stack bypass, plus IPv4-only-with-AAAA-NODATA and both-families-fail cases.
- `vitest run` 76/76, `tsc --noEmit` clean.

Surfaced by the EEP protocol audit (finding **SEC-1**). One of 8 split PRs from the audit quick-wins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
