### PR TITLE
fix(validator): accept catalog event types with underscores

### DIFF
--- a/packages/@eep-dev/validator/src/index.ts
+++ b/packages/@eep-dev/validator/src/index.ts
@@ -147,8 +147,10 @@ function ipv4ToBigInt(ip: string): bigint {
  * Supports flat dot-notation and wildcard suffix (e.g., 'com.example.entity.*').
  */
 export function validateEventTypePattern(pattern: string): boolean {
-    // Allow: lowercase.separated.parts and optional .* suffix
-    return /^[a-z][a-z0-9]*(\.[a-z][a-z0-9]*)*(\.\*)?$/.test(pattern);
+    // Allow: lowercase.separated.parts and optional .* suffix. Underscores are
+    // permitted within non-leading segments so the spec's own catalog event types
+    // (e.g. com.acme.product.price_changed, gate.access_granted) validate. See §8.
+    return /^[a-z][a-z0-9]*(\.[a-z][a-z0-9_]*)*(\.\*)?$/.test(pattern);
 }
 
 /**

--- a/packages/@eep-dev/validator/src/security.test.ts
+++ b/packages/@eep-dev/validator/src/security.test.ts
@@ -126,5 +126,17 @@ describe('Validator Security', () => {
         it('rejects patterns with null bytes', () => {
             expect(validateEventTypePattern('md.more\x00.entity')).toBe(false);
         });
+
+        it('accepts the spec catalog event types that use underscores', () => {
+            // §8/§9 use snake_case in suffix segments; these MUST validate.
+            expect(validateEventTypePattern('com.acme.product.price_changed')).toBe(true);
+            expect(validateEventTypePattern('gate.access_granted')).toBe(true);
+            expect(validateEventTypePattern('com.example.entity.*')).toBe(true);
+        });
+
+        it('still rejects a leading underscore or underscore in the root segment', () => {
+            expect(validateEventTypePattern('_private.event')).toBe(false);
+            expect(validateEventTypePattern('com_root.event')).toBe(false);
+        });
     });
 });

--- a/packages/eep-validator-python/eep_validator/__init__.py
+++ b/packages/eep-validator-python/eep_validator/__init__.py
@@ -117,7 +117,9 @@ def validate_ssrf_sync(url_string: str, *, allow_http: bool = False) -> None:
 
 # ── Event Type Validation ──────────────────────────────────────────────────────
 
-_EVENT_TYPE_RE = re.compile(r"^[a-z][a-z0-9]*(\.[a-z][a-z0-9]*)*(\.\*)?$")
+# Underscores are permitted within non-leading segments so the spec's own catalog
+# event types (e.g. com.acme.product.price_changed, gate.access_granted) validate. See §8.
+_EVENT_TYPE_RE = re.compile(r"^[a-z][a-z0-9]*(\.[a-z][a-z0-9_]*)*(\.\*)?$")
 
 
 def validate_event_type_pattern(pattern: str) -> bool:

--- a/packages/eep-validator-python/tests/test_validator.py
+++ b/packages/eep-validator-python/tests/test_validator.py
@@ -64,6 +64,14 @@ class TestEventTypePattern:
     def test_valid_wildcard(self):
         assert validate_event_type_pattern("com.example.entity.*") is True
 
+    def test_valid_underscore_suffix_segments(self):
+        # §8/§9 catalog uses snake_case in suffix segments; these MUST validate.
+        assert validate_event_type_pattern("com.acme.product.price_changed") is True
+        assert validate_event_type_pattern("gate.access_granted") is True
+
+    def test_rejects_underscore_in_root_segment(self):
+        assert validate_event_type_pattern("com_root.entity") is False
+
     def test_rejects_uppercase(self):
         assert validate_event_type_pattern("com.example.Entity.*") is False
 

--- a/schemas/v0.1/event.envelope.json
+++ b/schemas/v0.1/event.envelope.json
@@ -39,7 +39,7 @@
     "type": {
       "type": "string",
       "description": "The event type in reverse-domain dot notation. Format: {reverse-domain}.{entity-type}.{action}. Well-known EEP event types are listed in eep_known_event_types below and documented normatively in SPECIFICATION.md §13.",
-      "pattern": "^[a-z][a-z0-9]*(\\.[a-z][a-z0-9]*)+$",
+      "pattern": "^[a-z][a-z0-9]*(\\.[a-z][a-z0-9_]*)+$",
       "minLength": 5,
       "examples": [
         "com.example.entity.updated",

--- a/tests/test_schemas.test.ts
+++ b/tests/test_schemas.test.ts
@@ -158,6 +158,15 @@ describe('EEP JSON Schema Validation', () => {
             expect(validate(makeValidEnvelope({ type: 'a.b' }))).toBe(false);
         });
 
+        it('accepts catalog event types with underscores in suffix segments (§8/§9)', () => {
+            expect(validate(makeValidEnvelope({ type: 'com.acme.product.price_changed' }))).toBe(true);
+            expect(validate(makeValidEnvelope({ type: 'gate.access_granted' }))).toBe(true);
+        });
+
+        it('still rejects an underscore in the root segment', () => {
+            expect(validate(makeValidEnvelope({ type: 'com_root.entity.updated' }))).toBe(false);
+        });
+
         it('rejects non-ISO8601 time', () => {
             expect(validate(makeValidEnvelope({ time: 'not-a-date' }))).toBe(false);
         });


### PR DESCRIPTION
## Problem
The envelope `type` pattern (`schemas/v0.1/event.envelope.json`) and the `validateEventTypePattern` regex in both `@eep-dev/validator` and `eep-validator-python` forbade underscores. But the spec's own §8/§9 event catalog uses snake_case in suffix segments — e.g. `com.acme.product.price_changed`, `gate.access_granted`. So the schema and validators **rejected the protocol's own documented event types**.

## Fix
- Relax the pattern to permit `_` within **non-leading** segments only (the root/reverse-domain segment still cannot contain `_`, and uppercase is still rejected).
- Applied consistently in the schema, the TS validator, and the Python validator.

## Tests
- Positive tests (`price_changed`, `access_granted`) + negative tests (root-segment underscore) added to the schema suite, the TS validator suite, and the Python validator suite.
- validator 72/72, schema 110/110, Python validator 21/21; `tsc --noEmit` clean.

Surfaced by the EEP protocol audit (finding **event-type-regex-rejects-own-catalog**). Touches `validator/src/index.ts` and `security.test.ts` in regions disjoint from #38, so the two merge cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
