### PR TITLE
fix(middleware-python): close gate bypass + SSRF-check webhook callbacks (C1)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -304,6 +304,10 @@ jobs:
       - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
+      # Gate resolution + SSRF validation live in sibling packages. Install them
+      # editable first so the eep-gates / eep-validator requirements resolve locally
+      # instead of from PyPI (mirrors the TS test-middleware workspace build step).
+      - run: pip install -e ../eep-gates-python -e ../eep-validator-python
       - run: pip install -e '.[dev]'
       - run: python -m pytest -q
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,19 @@ All notable changes to this repository are documented here. The format is loosel
 
 ## Unreleased
 
-- (nothing yet)
+### Security
+
+- **`eep-middleware` (Python) — removed a gate bypass and added webhook SSRF
+  validation.** `EEPServer.resolve_gated_resource` previously granted premium
+  access to any request carrying a hard-coded `{"type":"payment","token":"tok_valid"}`
+  proof, ignoring the gate config and any semantic verifier. It now resolves
+  access through `eep_gates.resolve_access` with strict semantic verification
+  (fails closed; register `proof_verifiers` for real checks), reaching parity
+  with the TypeScript `@eep-dev/middleware`. `POST /eep/subscribe` now requires
+  a `delivery_url` for webhook subscriptions and validates it with
+  `eep_validator.validate_ssrf` before persisting, rejecting callbacks to
+  private / loopback / link-local addresses. `eep-gates` and `eep-validator`
+  are now declared dependencies. Surfaced by the EEP protocol audit.
 
 ## [0.1.0] - 2026-05-19
 

--- a/packages/eep-middleware-python/README.md
+++ b/packages/eep-middleware-python/README.md
@@ -4,12 +4,18 @@ Python middleware for integrating **EEP** into FastAPI, Flask, or Django: framew
 
 ## Install
 
-From the EEP monorepo:
+From the EEP monorepo (install the sibling packages this middleware depends on first,
+so the `eep-gates` / `eep-validator` requirements resolve locally instead of from PyPI):
 
 ```bash
-cd EEP/packages/eep-middleware-python
-pip install -e .
+cd EEP/packages
+pip install -e ./eep-gates-python -e ./eep-validator-python
+pip install -e ./eep-middleware-python
 ```
+
+`eep-middleware` depends on **`eep-gates`** (gate resolution + 402 responses) and
+**`eep-validator`** (SSRF checks for webhook callbacks), mirroring the TypeScript
+`@eep-dev/middleware` dependency on `@eep-dev/gates` and `@eep-dev/validator`.
 
 Or add as a path dependency in `pyproject.toml`:
 
@@ -62,6 +68,42 @@ app.register_blueprint(create_eep_blueprint(server))
 ## Django
 
 Use **`get_eep_urlpatterns(server)`** from `eep_middleware.django` and include them in your URLconf (see package source for signature).
+
+## Gated resources & proof verification
+
+`server.resolve_gated_resource(resource, headers)` resolves access against the
+configured `gate_config` using **`eep_gates.resolve_access`** with
+`strict_semantic_verification=True`. It fails closed: a requirement is only
+satisfied when a registered **proof verifier** confirms the proof. Without a
+verifier for a requirement type, that requirement stays unmet and the caller
+gets a spec-compliant **402** body from `build_402_response`.
+
+Register verifiers through the constructor:
+
+```python
+from eep_gates import ProofVerifier
+
+class PaymentVerifier(ProofVerifier):
+    @property
+    def supported_types(self): return ["payment"]
+    async def verify(self, proof, requirement) -> bool:
+        return await my_settlement_lookup(proof.get("token"))  # real check
+
+server = EEPServer(
+    base_url="https://api.example.com",
+    did="did:web:example.com",
+    gate_config=my_gate_config,
+    proof_verifiers=[PaymentVerifier()],
+)
+```
+
+> There is **no** built-in "accept any token" shortcut. Earlier drafts granted
+> premium access to a hard-coded placeholder token; that backdoor has been removed.
+
+Webhook subscriptions (`POST /eep/subscribe`, `delivery_method: "webhook"`)
+require a `delivery_url`, which is validated with **`eep_validator.validate_ssrf`**
+before it is stored — callbacks to private / loopback / link-local addresses are
+rejected with a 400.
 
 ## Adapters
 

--- a/packages/eep-middleware-python/eep_middleware/core.py
+++ b/packages/eep-middleware-python/eep_middleware/core.py
@@ -4,6 +4,9 @@ import json
 import time
 from typing import Any, Callable
 
+from eep_gates import ProofVerifier, ProofVerifierRegistry, build_402_response, resolve_access
+from eep_validator import SSRFError, validate_ssrf
+
 from eep_middleware.adapters import AuthAdapter, CloudEvent, DBAdapter, EventBusAdapter, SubscriptionRecord
 from eep_middleware.db.in_memory import InMemoryDBAdapter
 from eep_middleware.event_bus.in_memory import InMemoryEventBusAdapter
@@ -33,6 +36,7 @@ class EEPServer:
         auth_adapter: AuthAdapter | None = None,
         db_adapter: DBAdapter | None = None,
         event_bus_adapter: EventBusAdapter | None = None,
+        proof_verifiers: list[ProofVerifier] | None = None,
     ) -> None:
         self.base_url = base_url.rstrip("/")
         self.did = did
@@ -46,6 +50,12 @@ class EEPServer:
         self.auth_adapter = auth_adapter or HeaderProofAuthAdapter()
         self.db_adapter = db_adapter or InMemoryDBAdapter()
         self.event_bus_adapter = event_bus_adapter or InMemoryEventBusAdapter()
+        # Semantic proof verifiers (e.g. payment settlement, trust lookup). Without a
+        # verifier for a requirement type, that requirement stays unmet under strict
+        # verification — the server fails closed rather than trusting unverified proofs.
+        self.verifier_registry = ProofVerifierRegistry()
+        for verifier in proof_verifiers or []:
+            self.verifier_registry.register(verifier)
 
     def manifest_payload(self) -> dict[str, Any]:
         return {
@@ -77,16 +87,17 @@ class EEPServer:
     async def resolve_gated_resource(self, resource: str | None, headers: dict[str, str]) -> tuple[int, dict[str, Any]]:
         target_resource = resource or "entity.public.profile"
         proofs = await self.auth_adapter.extract_proofs(headers, None)
-        if target_resource == "entity.public.profile":
-            return 200, {"resource": target_resource, "tier": "public", "data": {"value": "access_granted"}}
-        if any(isinstance(item, dict) and item.get("type") == "payment" and item.get("token") == "tok_valid" for item in proofs):
-            return 200, {"resource": target_resource, "tier": "premium", "data": {"value": "access_granted"}}
-        return 402, {
-            "error": "access_restricted",
-            "resource": target_resource,
-            "required_tier": "premium",
-            "current_tier": "public",
-        }
+        access = await resolve_access(
+            proofs,
+            self.gate_config,
+            target_resource,
+            self.verifier_registry,
+            strict_semantic_verification=True,
+        )
+        if not access.granted:
+            payload = await build_402_response(self.gate_config, target_resource, proofs)
+            return 402, payload
+        return 200, {"resource": target_resource, "tier": access.tier, "data": {"value": "access_granted"}}
 
     async def create_subscription(self, payload: dict[str, Any]) -> tuple[int, dict[str, Any]]:
         source_did = payload.get("source_did")
@@ -94,11 +105,27 @@ class EEPServer:
         if not isinstance(source_did, str) or delivery_method not in {"sse", "webhook"}:
             return 400, {"error": "invalid_request", "message": "source_did and delivery_method are required"}
 
+        delivery_url = str(payload["delivery_url"]) if isinstance(payload.get("delivery_url"), str) else None
+
+        # Webhook deliveries are fetched server-side, so the callback URL is an SSRF
+        # vector: validate it points at a public address before persisting it. SSE
+        # deliveries are client-initiated and need no callback URL.
+        if delivery_method == "webhook":
+            if not delivery_url:
+                return 400, {
+                    "error": "invalid_request",
+                    "message": "delivery_url is required when delivery_method is webhook",
+                }
+            try:
+                await validate_ssrf(delivery_url)
+            except SSRFError as err:
+                return 400, {"error": "invalid_request", "message": f"delivery_url is not allowed: {err}"}
+
         subscription = SubscriptionRecord(
             subscription_id=f"sub_{int(time.time() * 1000)}",
             source_did=source_did,
             delivery_method=str(delivery_method),
-            callback_url=str(payload["delivery_url"]) if isinstance(payload.get("delivery_url"), str) else None,
+            callback_url=delivery_url,
             created_at=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
         )
         await self.db_adapter.save_subscription(subscription)

--- a/packages/eep-middleware-python/pyproject.toml
+++ b/packages/eep-middleware-python/pyproject.toml
@@ -24,6 +24,11 @@ classifiers = [
 ]
 dependencies = [
     "fastapi>=0.110",
+    # Gate resolution + SSRF validation are shared with the TypeScript middleware.
+    # In the monorepo these resolve to the sibling packages installed editable
+    # (see test.sh / CI). When published they resolve from PyPI.
+    "eep-gates>=0.1.0",
+    "eep-validator>=0.1.0",
 ]
 
 [project.optional-dependencies]

--- a/packages/eep-middleware-python/tests/test_core.py
+++ b/packages/eep-middleware-python/tests/test_core.py
@@ -1,10 +1,40 @@
+from typing import Any, Dict, List
+
 import pytest
 
+from eep_gates import ProofVerifier
 from eep_middleware.core import EEPServer
 
 
+class _PaymentVerifier(ProofVerifier):
+    """Test verifier that only accepts the sentinel token ``tok_valid``.
+
+    Mirrors the ``paymentVerifier`` in the TypeScript ``eep-server.test.ts``: a
+    payment proof is semantically valid only when the platform confirms it.
+    """
+
+    @property
+    def supported_types(self) -> List[str]:
+        return ["payment"]
+
+    async def verify(self, proof: Dict[str, Any], requirement: Dict[str, Any]) -> bool:
+        return proof.get("token") == "tok_valid"
+
+
+_GATED_CONFIG = {
+    "default_tier": "public",
+    "tiers": {
+        "public": {"requirements": [], "access": ["entity.public.profile"]},
+        "premium": {
+            "requirements": [{"type": "payment", "amount": 1, "currency": "usd", "per": "request"}],
+            "access": ["content.papers.full_text"],
+        },
+    },
+}
+
+
 @pytest.mark.asyncio
-async def test_core_manifest_entity_and_gated_resolution_paths() -> None:
+async def test_manifest_and_entity_payloads() -> None:
     server = EEPServer(base_url="https://api.example.com/", did="did:web:example.com")
     manifest = server.manifest_payload()
     assert manifest["did"] == "did:web:example.com"
@@ -12,55 +42,146 @@ async def test_core_manifest_entity_and_gated_resolution_paths() -> None:
 
     entity = server.entity_payload("u", "alice")
     assert entity["did"] == "did:web:example.com:u:alice"
-
-    default_entity = server.entity_payload()
-    assert default_entity["id"] == "default"
-
-    denied_status, denied = await server.resolve_gated_resource("content.papers.full_text", {})
-    assert denied_status == 402
-    assert denied["error"] == "access_restricted"
-
-    granted_status, granted = await server.resolve_gated_resource("content.papers.full_text", {"x-eep-proofs": '[{"type":"payment","token":"tok_valid"}]'})
-    assert granted_status == 200
-    assert granted["tier"] == "premium"
-
-    public_status, public = await server.resolve_gated_resource(None, {})
-    assert public_status == 200
-    assert public["tier"] == "public"
-
-    non_list_status, _ = await server.resolve_gated_resource(
-        "content.papers.full_text", {"x-eep-proofs": '{"type":"payment"}'}
-    )
-    assert non_list_status == 402
-
-    parse_error_status, _ = await server.resolve_gated_resource(
-        "content.papers.full_text", {"x-eep-proofs": "not-json"}
-    )
-    assert parse_error_status == 402
+    assert server.entity_payload()["id"] == "default"
 
 
 @pytest.mark.asyncio
-async def test_core_subscription_and_audit_paths() -> None:
+async def test_public_resource_is_granted_without_proofs() -> None:
+    server = EEPServer(base_url="https://api.example.com", did="did:web:example.com")
+    status, body = await server.resolve_gated_resource(None, {})
+    assert status == 200
+    assert body["tier"] == "public"
+
+
+@pytest.mark.asyncio
+async def test_gated_resource_denied_without_proofs() -> None:
+    server = EEPServer(base_url="https://api.example.com", did="did:web:example.com")
+    status, body = await server.resolve_gated_resource("content.papers.full_text", {})
+    assert status == 402
+    assert body["error"] == "access_restricted"
+
+
+@pytest.mark.asyncio
+async def test_payment_token_alone_does_not_grant_access() -> None:
+    """Regression: a bare ``tok_valid`` payment token must NOT bypass gating.
+
+    The previous implementation hard-coded ``token == "tok_valid"`` as a premium
+    grant, ignoring the gate config and any semantic verifier — a backdoor that
+    handed premium content to anyone who guessed the placeholder string.
+    """
+    server = EEPServer(base_url="https://api.example.com", did="did:web:example.com")
+    headers = {"x-eep-proofs": '[{"type":"payment","token":"tok_valid"}]'}
+    status, _ = await server.resolve_gated_resource("content.papers.full_text", headers)
+    assert status == 402
+
+
+@pytest.mark.asyncio
+async def test_malformed_proofs_are_ignored() -> None:
     server = EEPServer(base_url="https://api.example.com", did="did:web:example.com")
 
-    bad_status, bad_body = await server.create_subscription({})
-    assert bad_status == 400
-    assert bad_body["error"] == "invalid_request"
+    non_list, _ = await server.resolve_gated_resource(
+        "content.papers.full_text", {"x-eep-proofs": '{"type":"payment"}'}
+    )
+    assert non_list == 402
 
-    created_status, created_body = await server.create_subscription(
+    parse_error, _ = await server.resolve_gated_resource(
+        "content.papers.full_text", {"x-eep-proofs": "not-json"}
+    )
+    assert parse_error == 402
+
+
+@pytest.mark.asyncio
+async def test_configured_gate_grants_access_with_verified_proof() -> None:
+    server = EEPServer(
+        base_url="https://api.example.com",
+        did="did:web:example.com",
+        gate_config=_GATED_CONFIG,
+        proof_verifiers=[_PaymentVerifier()],
+    )
+    headers = {"x-eep-proofs": '[{"type":"payment","token":"tok_valid"}]'}
+    status, body = await server.resolve_gated_resource("content.papers.full_text", headers)
+    assert status == 200
+    assert body["tier"] == "premium"
+
+
+@pytest.mark.asyncio
+async def test_gated_tier_denied_when_verifier_rejects_proof() -> None:
+    server = EEPServer(
+        base_url="https://api.example.com",
+        did="did:web:example.com",
+        gate_config=_GATED_CONFIG,
+        proof_verifiers=[_PaymentVerifier()],
+    )
+    headers = {"x-eep-proofs": '[{"type":"payment","token":"tok_wrong"}]'}
+    status, _ = await server.resolve_gated_resource("content.papers.full_text", headers)
+    assert status == 402
+
+
+@pytest.mark.asyncio
+async def test_subscription_requires_source_did_and_method() -> None:
+    server = EEPServer(base_url="https://api.example.com", did="did:web:example.com")
+    status, body = await server.create_subscription({})
+    assert status == 400
+    assert body["error"] == "invalid_request"
+
+
+@pytest.mark.asyncio
+async def test_webhook_subscription_requires_delivery_url() -> None:
+    server = EEPServer(base_url="https://api.example.com", did="did:web:example.com")
+    status, body = await server.create_subscription(
+        {"source_did": "did:web:agent.example", "delivery_method": "webhook"}
+    )
+    assert status == 400
+    assert "delivery_url" in body["message"]
+
+
+@pytest.mark.asyncio
+async def test_webhook_subscription_rejects_ssrf_unsafe_url() -> None:
+    """A webhook delivery_url that resolves to a private/loopback address is rejected."""
+    server = EEPServer(base_url="https://api.example.com", did="did:web:example.com")
+    status, body = await server.create_subscription(
         {
             "source_did": "did:web:agent.example",
             "delivery_method": "webhook",
-            "delivery_url": "https://hook.example",
+            "delivery_url": "https://127.0.0.1/hook",
         }
     )
-    assert created_status == 201
-    loaded = await server.get_subscription(created_body["subscription_id"])
+    assert status == 400
+    assert body["error"] == "invalid_request"
+    assert "delivery_url" in body["message"]
+
+
+@pytest.mark.asyncio
+async def test_webhook_subscription_accepts_safe_url(monkeypatch: pytest.MonkeyPatch) -> None:
+    server = EEPServer(base_url="https://api.example.com", did="did:web:example.com")
+
+    async def _allow(_url: str) -> None:
+        return None
+
+    monkeypatch.setattr("eep_middleware.core.validate_ssrf", _allow)
+    status, body = await server.create_subscription(
+        {
+            "source_did": "did:web:agent.example",
+            "delivery_method": "webhook",
+            "delivery_url": "https://hook.example/notify",
+        }
+    )
+    assert status == 201
+    assert body["callback_url"] == "https://hook.example/notify"
+    loaded = await server.get_subscription(body["subscription_id"])
     assert loaded is not None
     assert (await server.get_subscription("missing")) is None
 
+
+@pytest.mark.asyncio
+async def test_sse_subscription_skips_ssrf_and_audits() -> None:
+    server = EEPServer(base_url="https://api.example.com", did="did:web:example.com")
+    status, _ = await server.create_subscription(
+        {"source_did": "did:web:agent.example", "delivery_method": "sse"}
+    )
+    assert status == 201
+
     events: list[str] = []
     await server.subscribe_to_events("subscription.*", lambda event: events.append(event.event_type))
-
     audit = await server.audit_payload()
     assert audit["subscriptions_count"] == 1

--- a/packages/eep-middleware-python/tests/test_framework_adapters.py
+++ b/packages/eep-middleware-python/tests/test_framework_adapters.py
@@ -1,14 +1,43 @@
+from typing import Any, Dict, List
+
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+from eep_gates import ProofVerifier
 from eep_middleware import create_eep_blueprint, create_eep_router, get_eep_urlpatterns
 from eep_middleware.core import EEPServer
 
 
+class _PaymentVerifier(ProofVerifier):
+    @property
+    def supported_types(self) -> List[str]:
+        return ["payment"]
+
+    async def verify(self, proof: Dict[str, Any], requirement: Dict[str, Any]) -> bool:
+        return proof.get("token") == "tok_valid"
+
+
+_GATED_CONFIG = {
+    "default_tier": "public",
+    "tiers": {
+        "public": {"requirements": [], "access": ["entity.public.profile"]},
+        "premium": {
+            "requirements": [{"type": "payment", "amount": 1, "currency": "usd", "per": "request"}],
+            "access": ["content.papers.full_text"],
+        },
+    },
+}
+
+
 @pytest.mark.asyncio
 async def test_fastapi_router_endpoints() -> None:
-    server = EEPServer(base_url="https://api.example.com", did="did:web:example.com")
+    server = EEPServer(
+        base_url="https://api.example.com",
+        did="did:web:example.com",
+        gate_config=_GATED_CONFIG,
+        proof_verifiers=[_PaymentVerifier()],
+    )
     app = FastAPI()
     app.include_router(create_eep_router(server))
     client = TestClient(app)

--- a/test.sh
+++ b/test.sh
@@ -62,7 +62,10 @@ echo "━━━ Python: eep-mcp-bridge ━━━"
 
 echo ""
 echo "━━━ Python: eep-middleware ━━━"
-(cd "$ROOT_DIR/packages/eep-middleware-python" && pip install -e '.[dev]' -q && python3 -m pytest -q)
+(cd "$ROOT_DIR/packages/eep-middleware-python" \
+  && pip install -e ../eep-gates-python -e ../eep-validator-python -q \
+  && pip install -e '.[dev]' -q \
+  && python3 -m pytest -q)
 
 echo ""
 echo "━━━ llms.txt / llms-full.txt ━━━"


### PR DESCRIPTION
## Summary

Fixes audit finding **C1 (Critical)**: the Python `eep-middleware` had a hard-coded gate bypass and no SSRF protection on webhook callbacks.

- **Gate bypass removed.** `EEPServer.resolve_gated_resource` previously returned a `200` premium grant to any request carrying the placeholder proof `{"type":"payment","token":"tok_valid"}`, ignoring the gate config and every semantic verifier. It now resolves access through `eep_gates.resolve_access` with **strict semantic verification** (fails closed) and returns `build_402_response(...)` on denial — parity with the TypeScript `@eep-dev/middleware`.
- **Webhook SSRF validation added.** `POST /eep/subscribe` now requires a `delivery_url` for `webhook` subscriptions and validates it with `eep_validator.validate_ssrf` before persisting, rejecting callbacks to private / loopback / link-local hosts. SSE subscriptions are unaffected.
- **Proof verifiers are now injectable.** `EEPServer(..., proof_verifiers=[...])` registers real verifiers; with none registered the server denies gated tiers (secure default).
- **Dependencies wired.** `eep-gates` and `eep-validator` are declared in `pyproject.toml`; `test.sh` and the `test-middleware-python` CI job install the siblings editable first so requirements resolve locally (mirrors the existing TS `test-middleware` workspace step).

### Before / after

```python
# before — anyone sending the placeholder string got premium content
if any(p.get("type") == "payment" and p.get("token") == "tok_valid" for p in proofs):
    return 200, {"tier": "premium", ...}

# after — config-driven, fails closed, verifier-backed
access = await resolve_access(proofs, self.gate_config, target_resource,
                              self.verifier_registry, strict_semantic_verification=True)
if not access.granted:
    return 402, await build_402_response(self.gate_config, target_resource, proofs)
```

## Test plan

- [x] `pytest` for `eep-middleware-python`: **22 passed**, **100% line/branch coverage** (gate-grant, gate-deny-without-proof, `tok_valid`-alone-now-402, malformed-proof-ignored, verified-proof-grants, verifier-rejects-denies, webhook-requires-url, webhook-rejects-SSRF, webhook-accepts-safe-url, SSE-skips-SSRF).
- [x] `test_framework_adapters.py` updated to construct `EEPServer` with a real `gate_config` + `proof_verifiers` (no backdoor).
- [ ] CI `test-middleware-python` job green on this branch (installs `eep-gates-python` + `eep-validator-python` editable, then runs pytest).

## Notes for reviewer

- This is a **behavior change**: integrators relying on the `tok_valid` placeholder will now get `402`. That placeholder was a test/demo backdoor, never a real auth path.
- No change to the TypeScript middleware in this PR; it already resolved gates correctly. Remaining audit items (C2 auth adapters, C3 gates specificity, H1–H9) follow in separate PRs.
