### PR TITLE
ci(audit): scope blocking npm-audit gate to published packages

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,18 +22,22 @@ jobs:
           npm ci
           npm run build
 
-      - name: npm high-severity audit gate
+      - name: npm high-severity audit gate (published packages — blocking)
         run: |
           set -euo pipefail
+          # Only packages we publish to npm gate the build: a high-severity
+          # advisory in one of these ships to consumers. Examples and the test
+          # harness are audited in a separate, non-blocking step below — a vuln
+          # in a demo's transitive dependency must not block every contributor
+          # PR (it previously blocked main and 8 PRs over a hono advisory in
+          # examples/node-gate-publisher).
           for dir in \
             "packages/@eep-dev/gates" \
             "packages/@eep-dev/signer" \
             "packages/@eep-dev/validator" \
             "packages/@eep-dev/compliance-cli" \
             "packages/@eep-dev/setup-cli" \
-            "packages/@eep-dev/middleware" \
-            "tests" \
-            "examples/node-gate-publisher"
+            "packages/@eep-dev/middleware"
           do
             echo "Auditing $dir"
             (cd "$dir" && npm ci && npm audit --omit=dev --audit-level=high)
@@ -42,6 +46,24 @@ jobs:
           (cd "packages/@eep-dev/discovery" && npm install && npm audit --omit=dev --audit-level=high)
           echo "Auditing packages/@eep-dev/mcp-bridge"
           (cd "packages/@eep-dev/mcp-bridge" && npm install && npm audit --omit=dev --audit-level=high)
+
+      - name: npm audit (examples + test harness — advisory, non-blocking)
+        continue-on-error: true
+        run: |
+          # These are not published to npm. High-severity transitive advisories
+          # here are surfaced as warnings but do NOT fail CI.
+          for dir in \
+            "tests" \
+            "examples/node-gate-publisher"
+          do
+            echo "::group::Advisory audit $dir"
+            if (cd "$dir" && npm ci && npm audit --omit=dev --audit-level=high); then
+              echo "$dir: no high-severity advisories"
+            else
+              echo "::warning title=Advisory audit::$dir has high-severity advisories (non-blocking: not a published package)"
+            fi
+            echo "::endgroup::"
+          done
 
       - uses: actions/setup-python@v6
         with:


### PR DESCRIPTION
## Summary

Audit finding (community/contributor + supply-chain verticals): the
`dependency-policy` CI gate audited **examples and the test harness in the
same blocking loop** as published packages with `--audit-level=high`. A
high-severity advisory in a *demo's* transitive dependency therefore failed
CI for **every** PR.

This is not hypothetical: a `hono` advisory in `examples/node-gate-publisher`
recently red-failed `main` and **8 open PRs** at once, even though nothing a
consumer installs was affected.

## Change

- **Blocking** audit now covers only the **published `@eep-dev/*` packages**
  (gates, signer, validator, compliance-cli, setup-cli, middleware, discovery,
  mcp-bridge) — a vulnerability in one of these ships to consumers, so it
  should gate the build.
- **`tests/` and `examples/node-gate-publisher`** move to a separate
  `continue-on-error: true` advisory step that surfaces high-severity
  advisories as CI **warnings** without failing the run.

No coverage is lost — examples/tests are still audited, just non-blocking.

## Verification

`python -c "yaml.safe_load(...)"` parses; the `dependency-policy` job on this
PR exercises the new split. Part of the EEP vertical-audit follow-up (Wave 1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
