### PR TITLE
fix(ci): pin prettier in the schema-types drift gate (unbreaks main)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -417,7 +417,14 @@ jobs:
           node-version: '22'
 
       - name: Install codegen dependency
-        run: npm install --no-save --no-package-lock json-schema-to-typescript@^15
+        # Pin BOTH json-schema-to-typescript and prettier to exact versions.
+        # jstt formats its output with prettier (dep range "^3.2.5"), so an
+        # unpinned install silently adopts new prettier releases and reformats
+        # the generated types — drift with no schema change. prettier 3.9.0
+        # (2026-06-27) collapsed short union types onto one line and broke this
+        # gate on main. The committed tests/types/eep-schemas.d.ts is generated
+        # against exactly these versions; bump them here and regenerate together.
+        run: npm install --no-save --no-package-lock json-schema-to-typescript@15.0.4 prettier@3.9.0
 
       - name: Check generated schema types are up to date
         # The script's --check mode generates the output to memory and

--- a/scripts/codegen-schema-types.mjs
+++ b/scripts/codegen-schema-types.mjs
@@ -14,9 +14,15 @@
  *   node scripts/codegen-schema-types.mjs            # generate
  *   node scripts/codegen-schema-types.mjs --check    # generate to a temp dir and compare
  *
- * Dependencies (devDependencies of the repo root):
- *   - json-schema-to-typescript
+ * Dependencies (pin these EXACTLY — json-schema-to-typescript formats its
+ * output with prettier, so an unpinned prettier silently reformats the
+ * generated types and breaks the drift gate with no schema change):
+ *   - json-schema-to-typescript@15.0.4
+ *   - prettier@3.9.0
  *   - datamodel-code-generator (Python, run via pipx in CI)
+ *
+ * Install locally before regenerating:
+ *   npm install --no-save --no-package-lock json-schema-to-typescript@15.0.4 prettier@3.9.0
  *
  * This script is intentionally modest: it does not aim to replace the
  * hand-maintained TypeScript surfaces in @eep-dev/* packages. Its job

--- a/tests/types/eep-schemas.d.ts
+++ b/tests/types/eep-schemas.d.ts
@@ -224,14 +224,7 @@ export interface AuditEntry {
    * For gate events: the type of gate requirement (credential, payment, agreement, data_request, identity, combined).
    */
   gate_type?:
-    | 'credential'
-    | 'payment'
-    | 'agreement'
-    | 'data_request'
-    | 'identity'
-    | 'allowlist'
-    | 'reciprocal'
-    | 'combined';
+    'credential' | 'payment' | 'agreement' | 'data_request' | 'identity' | 'allowlist' | 'reciprocal' | 'combined';
   /**
    * Short machine-readable reason code for failures. Not surfaced to requesting agents (logged internally only per EEP §10.8).
    */
@@ -2122,14 +2115,7 @@ export interface RegistryEntry {
    * Gate requirement types supported by this publisher. Agents filter by gate type when selecting interaction partners (e.g., ?gate=payment).
    */
   gate_types?: (
-    | 'credential'
-    | 'identity'
-    | 'agreement'
-    | 'data_request'
-    | 'payment'
-    | 'combined'
-    | 'proof_of_intent'
-    | 'public'
+    'credential' | 'identity' | 'agreement' | 'data_request' | 'payment' | 'combined' | 'proof_of_intent' | 'public'
   )[];
   /**
    * Protocol layers supported. Agents filter by layer capability (e.g., ?supports=sse).


### PR DESCRIPTION
## Fixes `main` (red after #54/#55 merges)

The **Schema types drift gate** is failing on `main`, but **PR #55 is
innocent** — it only bumped a dependabot lockfile in `@eep-dev/discovery`.

### Root cause

The gate installs `json-schema-to-typescript@^15` with `--no-package-lock`.
jstt formats its generated output with **prettier** (`"prettier": "^3.2.5"`),
so the unpinned install silently picks up new prettier releases:

- Last green run (#53, 06-25) used prettier 3.8.x.
- **prettier 3.9.0** published **2026-06-27 10:26 UTC** — it collapses short
  union types onto one line.
- #54 / #55 merge CI (14:11 / 14:15) installed 3.9.0 → the generated
  `tests/types/eep-schemas.d.ts` reformatted → drift, with **no schema change**.

```diff
-  gate_type?:
-    | 'credential'
-    | 'payment'
-    | ...
+  gate_type?:
+    'credential' | 'payment' | ...
```

(Reproduced locally by installing prettier 3.9.0; 3.8.x produces the committed
formatting.)

### Fix

- **Pin `json-schema-to-typescript@15.0.4` and `prettier@3.9.0` exactly** in the
  drift-gate install step (a determinism gate must not depend on a floating
  formatter), and document the pins in `scripts/codegen-schema-types.mjs`.
- **Regenerate `tests/types/eep-schemas.d.ts`** against the pinned versions so
  CI and the committed file agree. The only delta is prettier's union-wrapping.

After this lands, re-running the gate on `main` is green. Future prettier
releases require an intentional bump here + regenerate, instead of breaking
every PR. (A committed lockfile for the codegen toolchain would be the fuller
hardening — fits the supply-chain CI work in the audit's Wave 4.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
