### PR TITLE
docs(readme): point clone badge at the live gist

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 [![License](https://img.shields.io/badge/License-Apache%202.0-green)](./LICENSE)
 [![Contributor Covenant](https://img.shields.io/badge/Contributor%20Covenant-2.1-4baaaa.svg)](./CODE_OF_CONDUCT.md)
 [![EEP compatible](./assets/badges/eep-compatible.svg)](./docs/current/SPECIFICATION.md)
-[![GitHub Clones](https://img.shields.io/badge/dynamic/json?color=success&label=clones&query=count&url=https://gist.githubusercontent.com/ucekmez/__GIST_ID__/raw/clone.json&logo=github)](./docs/ops/clone-count-badge.md)
+[![GitHub Clones](https://img.shields.io/badge/dynamic/json?color=success&label=clones&query=count&url=https://gist.githubusercontent.com/ucekmez/ac633ddad9279deaf1639238c6258057/raw/clone.json&logo=github)](./docs/ops/clone-count-badge.md)
 
 <p align="center">
   <img src="./assets/realworld-demo.gif" alt="Two terminal panes running in parallel: an agent fetching the same quarterly report via current-web HTML scraping (~26s, ~46 KB, ~11.5K tokens, 2 simulated human steps) vs EEP (~10s, ~2.2 KB, ~386 tokens, 0 human steps). Deterministic, no LLM calls." width="1000"/>


### PR DESCRIPTION
## Summary

Activates the clone-count badge merged in #71. The README still carried the
`__GIST_ID__` placeholder, so shields.io fetched a 404 and rendered
**"resource not found"**. This points the badge URL at the configured gist
(`ucekmez/ac633ddad9279deaf1639238c6258057`).

## Verified working

- The `Clone count badge` workflow was dispatched on `main` and **succeeded**.
- The gist now holds real data (via the GitHub API, authoritative): **count
  1711, uniques 212, 14 days recorded** — so your PAT scopes (`repo` + `gist`)
  and the `GIST_ID` variable are all correct.
- The shields badge with this id renders **`clones: 1711`**.

(The earlier manual "Run workflow" never actually dispatched — the workflow had
zero runs — so the gist was still the seed `{count:0}`. It runs daily at 03:00
UTC from here on.)

Once merged, the README badge goes live. No CI/wire/schema impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
