### PR TITLE
fix(spec,middleware,compliance-cli): define one canonical subscription resource

### DIFF
--- a/docs/current/SPECIFICATION.md
+++ b/docs/current/SPECIFICATION.md
@@ -320,6 +320,30 @@ Content-Type: application/json
 
 The subscription sits in the `pending_verification` status until WebSub intent verification completes (see §10).
 
+#### 5.1.1 Subscription management endpoints (normative)
+
+`POST /eep/subscribe` creates a subscription and is the URL advertised as `layers.layer2_webhook` in the manifest (§12.3) and as `rel="subscribe"` in the `Link` header (§12.1). Every other operation on an existing subscription is addressed as a member of the `/eep/subscriptions` collection:
+
+| Method | Path | Operation | Success | Scope |
+|---|---|---|---|---|
+| `POST` | `/eep/subscribe` | Create a subscription | `201` + subscription object | `write:subscriptions` |
+| `GET` | `/eep/subscriptions` | List the caller's own subscriptions | `200` + `{ "subscriptions": [...] }` | `read:subscriptions` |
+| `GET` | `/eep/subscriptions/{subscription_id}` | Read one subscription's status | `200` + subscription object | `read:subscriptions` |
+| `DELETE` | `/eep/subscriptions/{subscription_id}` | Cancel a subscription | `204` | `write:subscriptions` |
+| `POST` | `/eep/subscriptions/{subscription_id}/pause` | Pause an `active` subscription | `200` + subscription object | `write:subscriptions` |
+| `POST` | `/eep/subscriptions/{subscription_id}/resume` | Resume a `paused` subscription | `200` + subscription object | `write:subscriptions` |
+| `POST` | `/eep/subscriptions/{subscription_id}/test` | Trigger a synthetic test delivery | `202` | `write:subscriptions` |
+
+Publishers MUST NOT return the `delivery_secret` on any of these responses; it is disclosed exactly once, in the `201` body of the creating `POST /eep/subscribe`.
+
+Publishers MUST scope every operation to the authenticated caller and MUST return `404` — not `403` — for a `subscription_id` that exists but belongs to another subscriber, so the collection cannot be enumerated.
+
+**Test deliveries.** `POST /eep/subscriptions/{subscription_id}/test` makes an `active` subscription's delivery path independently checkable: the publisher MUST send a normal, fully signed webhook to the registered `delivery_url` carrying an event of type `com.eep.subscription.test`, and MUST return `202 Accepted` once enqueued. The event MUST be signed and framed exactly like production traffic (§5.2, §5.3) — that is the entire point of the endpoint, and `@eep-dev/compliance-cli` relies on it to verify Standard Webhooks headers and HMAC correctness without waiting for organic traffic. Publishers MUST return `409 Conflict` when the subscription is not `active`, and MUST rate-limit this endpoint at least as tightly as subscription creation (§13).
+
+This table makes normative the API that [How to subscribe](../guides/how-to-subscribe.md#managing-subscriptions) has documented since v0.1; previously the guide was the only place these operations were written down.
+
+> **Compatibility note (v0.1).** Reference middleware released before this section served the member operations under `/eep/subscribe/{subscription_id}`. Implementations SHOULD continue to accept those paths as deprecated aliases through the `0.1.x` line and SHOULD advertise only the `/eep/subscriptions` forms.
+
 ### 5.2 Webhook delivery format
 
 The publisher MUST `POST` the following payload to the `delivery_url`:
@@ -648,7 +672,7 @@ EEP event types follow a reverse-domain dot notation pattern:
 ## 10. Subscription lifecycle
 
 ```
-POST /subscribe
+POST /eep/subscribe
       │
       ▼
   [pending_verification]
@@ -661,14 +685,18 @@ POST /subscribe
       │                             │
    Failure                   event delivery
       ▼                             │
-  [rejected]             5 consecutive failures
+  [rejected]             5 consecutive failed deliveries
                                     ▼
                               [paused]
                                     │
-                          POST /subscriptions/:id/resume
+      POST /eep/subscriptions/{subscription_id}/resume
                                     ▼
                               [active]
 ```
+
+A "failed delivery" is one that exhausted the full §5.4 retry schedule. The
+counter is consecutive and resets on the next delivery that the subscriber
+acknowledges with a 2xx. Endpoint paths are normative in §5.1.1.
 
 ### WebSub intent verification
 
@@ -1028,7 +1056,7 @@ Suitable for: read-only publishers, IoT sensors, knowledge bases.
 Superset of Core. Suitable for: B2B data APIs, financial feeds, subscription services.
 
 - [x] All Core requirements above, plus:
-- [x] Webhook subscription endpoint (`POST /eep/subscribe`) with full lifecycle (create/pause/resume/delete)
+- [x] Webhook subscription endpoints per §5.1.1: create (`POST /eep/subscribe`), read, list, resume, test and cancel under `/eep/subscriptions`
 - [x] WebSub intent verification before activating any webhook subscription
 - [x] HMAC-SHA256 signature on all webhook deliveries (Standard Webhooks: `webhook-id`, `webhook-timestamp`, `webhook-signature` per §5)
 - [x] Exponential backoff retry policy for failed webhook deliveries (min 5 attempts, max 24h window)

--- a/packages/@eep-dev/compliance-cli/src/index.ts
+++ b/packages/@eep-dev/compliance-cli/src/index.ts
@@ -111,6 +111,7 @@ const RECOMMENDATIONS: Record<string, string> = {
     'EEP discovery via Link header': 'Return a proper Link header with rel="subscribe" for entity/discovery endpoints.',
     'Subscription creation': 'Implement POST /eep/subscribe with valid schema, auth, and returned subscription_id + delivery_secret.',
     'WebSub Intent Verification': 'Perform challenge callback and echo hub.challenge exactly from subscriber endpoint.',
+    'Test delivery trigger (§5.1.1)': 'Implement POST /eep/subscriptions/{subscription_id}/test returning 202 and enqueueing a signed com.eep.subscription.test delivery to the registered delivery_url.',
     'Webhook delivery received': 'Implement deterministic test event trigger and retry-safe outbound delivery.',
     'Standard Webhooks headers present': 'Include webhook-id, webhook-timestamp, and webhook-signature on every webhook delivery.',
     'HMAC-SHA256 signature is valid': 'Sign webhook payloads using Standard Webhooks v1 content format and timing-safe verification.',
@@ -391,20 +392,45 @@ async function runTests() {
         receivedHeaders = null;
         receivedRawBody = null;
 
+        // Trigger a synthetic delivery via SPECIFICATION.md §5.1.1.
+        //
+        // This MUST report its own outcome. `fetch` only rejects on a
+        // transport error, so a 404 (publisher does not implement the
+        // endpoint) used to resolve normally — the runner then waited 5s,
+        // received nothing, and blamed the *delivery* rather than the
+        // missing trigger. Implementers saw "Webhook delivery received:
+        // FAIL" and went hunting in their own dispatcher.
+        let triggered = false;
         try {
-            await fetch(`${TARGET}/eep/subscriptions/${subscriptionId}/test`, {
+            const triggerRes = await fetch(`${TARGET}/eep/subscriptions/${subscriptionId}/test`, {
                 method: 'POST',
                 headers: { Authorization: `Bearer ${API_KEY}` },
                 signal: AbortSignal.timeout(5000),
             });
-        } catch {
-            fail('Test event delivery', 'failed to trigger test event');
+            if (triggerRes.status === 202 || triggerRes.ok) {
+                triggered = true;
+                logPass('Test delivery trigger (§5.1.1)', `HTTP ${triggerRes.status}`);
+            } else if (triggerRes.status === 404) {
+                logFail(
+                    'Test delivery trigger (§5.1.1)',
+                    `HTTP 404 — POST /eep/subscriptions/{id}/test is not implemented. ` +
+                    `Standard Webhooks header and HMAC probes cannot run without it.`
+                );
+            } else {
+                logFail('Test delivery trigger (§5.1.1)', `HTTP ${triggerRes.status}`);
+            }
+        } catch (e) {
+            logFail('Test delivery trigger (§5.1.1)', `request failed: ${String(e)}`);
         }
 
-        // Wait up to 5s for delivery
-        await new Promise(r => setTimeout(r, 5000));
+        // Only wait for a delivery we actually managed to trigger, and skip
+        // (rather than fail) the downstream signature probes otherwise — the
+        // publisher's signing is untested, not proven broken.
+        if (triggered) {
+            await new Promise(r => setTimeout(r, 5000));
+        }
 
-        if (receivedWebhook && receivedHeaders) {
+        if (triggered && receivedWebhook && receivedHeaders) {
             pass('Webhook delivery received', `event type: ${(receivedWebhook as any).type}`);
 
             // Verify Standard Webhooks headers
@@ -452,8 +478,19 @@ async function runTests() {
             if (event.eep_version) pass('EEP extension attributes present', `eep_version: ${event.eep_version}`);
             else fail('EEP extension attributes present', 'eep_version missing');
 
+        } else if (!triggered) {
+            // The trigger itself already failed and said so. Skip — rather
+            // than fail — everything downstream: the publisher's signing and
+            // envelope are untested here, not proven broken.
+            const reason = 'test delivery could not be triggered (see §5.1.1)';
+            skip('Webhook delivery received', reason);
+            skip('Standard Webhooks headers present', reason);
+            skip('HMAC-SHA256 signature is valid', reason);
+            skip('CloudEvents specversion is 1.0', reason);
+            skip('Event id field present', reason);
+            skip('Event source field present', reason);
         } else {
-            fail('Webhook delivery received', 'no webhook received within 5s');
+            fail('Webhook delivery received', 'trigger accepted but no webhook arrived within 5s');
             skip('Standard Webhooks headers present', 'no delivery');
             skip('HMAC-SHA256 signature is valid', 'no delivery');
             skip('CloudEvents specversion is 1.0', 'no delivery');

--- a/packages/@eep-dev/middleware/src/core/eep-server.test.ts
+++ b/packages/@eep-dev/middleware/src/core/eep-server.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { parseGateConfig, type GateProof, type ProofVerifier } from "@eep-dev/gates";
 import { EEPServer } from "./eep-server.js";
+import { TEST_DELIVERY_EVENT_TYPE } from "./request-handler.js";
 import type { EventBusAdapter, DBAdapter, SubscriptionRecord, SubscriptionUpdate } from "./request-handler.js";
 
 // Prevent real DNS resolution during subscribe validation tests.
@@ -44,8 +45,11 @@ class RecordingDBAdapter implements DBAdapter {
 
 class RecordingEventBusAdapter implements EventBusAdapter {
   public readonly published: string[] = [];
-  async publish(event: { type: string }): Promise<void> {
+  /** Full envelopes, for assertions that need more than the event type. */
+  public readonly events: Array<{ type: string; data?: unknown }> = [];
+  async publish(event: { type: string; data?: unknown }): Promise<void> {
     this.published.push(event.type);
+    this.events.push(event);
   }
   async subscribe(): Promise<void> {
     return;
@@ -294,11 +298,72 @@ describe("EEPServer", () => {
       did: "did:web:example.com"
     });
     const routes = server.getRouteDefinitions();
-    expect(routes.length).toBe(12);
+    expect(routes.length).toBe(18);
     const operationIds = routes.map((route) => route.operationId);
     expect(operationIds).toContain("subscribe");
     expect(operationIds).toContain("subscriptionStatus");
     expect(operationIds).toContain("unsubscribe");
+    expect(operationIds).toContain("listSubscriptions");
+    expect(operationIds).toContain("resumeSubscription");
+    expect(operationIds).toContain("pauseSubscription");
+    expect(operationIds).toContain("testSubscriptionDelivery");
+  });
+
+  // SPECIFICATION.md §5.1.1: creation stays on `POST /eep/subscribe` (it is
+  // what the manifest and the rel="subscribe" Link header advertise); every
+  // member operation is addressed under the `/eep/subscriptions` collection.
+  it("addresses subscription member operations under /eep/subscriptions", () => {
+    const server = new EEPServer({
+      baseUrl: "https://api.example.com",
+      did: "did:web:example.com"
+    });
+    const routes = server.getRouteDefinitions();
+    const find = (operationId: string) => routes.find((r) => r.operationId === operationId);
+
+    expect(find("subscribe")).toMatchObject({ method: "POST", path: "/eep/subscribe" });
+    expect(find("listSubscriptions")).toMatchObject({ method: "GET", path: "/eep/subscriptions" });
+    expect(find("subscriptionStatus")).toMatchObject({
+      method: "GET",
+      path: "/eep/subscriptions/:subscriptionId"
+    });
+    expect(find("unsubscribe")).toMatchObject({
+      method: "DELETE",
+      path: "/eep/subscriptions/:subscriptionId"
+    });
+    expect(find("pauseSubscription")).toMatchObject({
+      method: "POST",
+      path: "/eep/subscriptions/:subscriptionId/pause"
+    });
+    expect(find("resumeSubscription")).toMatchObject({
+      method: "POST",
+      path: "/eep/subscriptions/:subscriptionId/resume"
+    });
+    expect(find("testSubscriptionDelivery")).toMatchObject({
+      method: "POST",
+      path: "/eep/subscriptions/:subscriptionId/test"
+    });
+  });
+
+  it("keeps the pre-§5.1.1 /eep/subscribe/:id member paths as deprecated aliases", () => {
+    const server = new EEPServer({
+      baseUrl: "https://api.example.com",
+      did: "did:web:example.com"
+    });
+    const routes = server.getRouteDefinitions();
+    expect(routes).toContainEqual(
+      expect.objectContaining({
+        method: "GET",
+        path: "/eep/subscribe/:subscriptionId",
+        operationId: "subscriptionStatusDeprecated"
+      })
+    );
+    expect(routes).toContainEqual(
+      expect.objectContaining({
+        method: "DELETE",
+        path: "/eep/subscribe/:subscriptionId",
+        operationId: "unsubscribeDeprecated"
+      })
+    );
   });
 
   describe("subscribe body validation", () => {
@@ -527,6 +592,158 @@ describe("EEPServer", () => {
       });
       expect(res.status).toBe(201);
       expect(db.rows[0]?.tier).toBe("premium");
+    });
+  });
+
+  // SPECIFICATION.md §5.1.1 — list / resume / test-delivery member operations.
+  describe("subscription collection operations (§5.1.1)", () => {
+    const makeServer = () => {
+      const db = new RecordingDBAdapter();
+      const bus = new RecordingEventBusAdapter();
+      const server = new EEPServer({
+        baseUrl: "https://api.example.com",
+        did: "did:web:example.com",
+        dbAdapter: db,
+        eventBusAdapter: bus
+      });
+      return { db, bus, server };
+    };
+
+    const seed = async (db: RecordingDBAdapter, overrides: Partial<SubscriptionRecord> = {}) => {
+      const record: SubscriptionRecord = {
+        subscription_id: "sub_test_1",
+        source_did: "did:web:agent.example",
+        delivery_method: "webhook",
+        callback_url: "https://hook.example/notify",
+        event_types: ["com.example.entity.updated"],
+        status: "active",
+        failure_count: 0,
+        delivery_secret: "whsec_super_secret_value_1234",
+        created_at: new Date().toISOString(),
+        ...overrides
+      };
+      await db.saveSubscription(record);
+      return record;
+    };
+
+    it("lists subscriptions without ever re-exposing delivery_secret", async () => {
+      const { db, server } = makeServer();
+      await seed(db);
+      const res = await server.getSubscriptionListHandler()({
+        method: "GET",
+        path: "/eep/subscriptions",
+        headers: {}
+      });
+      expect(res.status).toBe(200);
+      const body = res.body as { count: number; subscriptions: Array<Record<string, unknown>> };
+      expect(body.count).toBe(1);
+      expect(body.subscriptions[0]).not.toHaveProperty("delivery_secret");
+      expect(body.subscriptions[0]?.subscription_id).toBe("sub_test_1");
+    });
+
+    it("resumes a paused subscription and clears its failure counter", async () => {
+      const { db, server } = makeServer();
+      await seed(db, { status: "paused", failure_count: 5 });
+      const res = await server.getSubscriptionResumeHandler()({
+        method: "POST",
+        path: "/eep/subscriptions/sub_test_1/resume",
+        headers: {},
+        params: { subscriptionId: "sub_test_1" }
+      });
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ status: "active", failure_count: 0 });
+      expect(res.body).not.toHaveProperty("delivery_secret");
+      expect(db.rows[0]?.status).toBe("active");
+      expect(db.rows[0]?.failure_count).toBe(0);
+    });
+
+    it("pauses an active subscription", async () => {
+      const { db, server } = makeServer();
+      await seed(db, { status: "active" });
+      const res = await server.getSubscriptionPauseHandler()({
+        method: "POST",
+        path: "/eep/subscriptions/sub_test_1/pause",
+        headers: {},
+        params: { subscriptionId: "sub_test_1" }
+      });
+      expect(res.status).toBe(200);
+      expect(res.body).toMatchObject({ status: "paused" });
+      expect(res.body).not.toHaveProperty("delivery_secret");
+      expect(db.rows[0]?.status).toBe("paused");
+    });
+
+    it("rejects pausing an already-paused subscription with 409", async () => {
+      const { db, server } = makeServer();
+      await seed(db, { status: "paused" });
+      const res = await server.getSubscriptionPauseHandler()({
+        method: "POST",
+        path: "/eep/subscriptions/sub_test_1/pause",
+        headers: {},
+        params: { subscriptionId: "sub_test_1" }
+      });
+      expect(res.status).toBe(409);
+    });
+
+    it("rejects resuming an already-active subscription with 409", async () => {
+      const { db, server } = makeServer();
+      await seed(db, { status: "active" });
+      const res = await server.getSubscriptionResumeHandler()({
+        method: "POST",
+        path: "/eep/subscriptions/sub_test_1/resume",
+        headers: {},
+        params: { subscriptionId: "sub_test_1" }
+      });
+      expect(res.status).toBe(409);
+    });
+
+    it("returns 404 when resuming an unknown subscription", async () => {
+      const { server } = makeServer();
+      const res = await server.getSubscriptionResumeHandler()({
+        method: "POST",
+        path: "/eep/subscriptions/nope/resume",
+        headers: {},
+        params: { subscriptionId: "nope" }
+      });
+      expect(res.status).toBe(404);
+    });
+
+    it("enqueues a test delivery addressed to exactly one subscription", async () => {
+      const { db, bus, server } = makeServer();
+      await seed(db);
+      const res = await server.getSubscriptionTestHandler()({
+        method: "POST",
+        path: "/eep/subscriptions/sub_test_1/test",
+        headers: {},
+        params: { subscriptionId: "sub_test_1" }
+      });
+      expect(res.status).toBe(202);
+      expect(bus.published).toEqual([TEST_DELIVERY_EVENT_TYPE]);
+      expect(bus.events[0]?.data).toMatchObject({ subscription_id: "sub_test_1" });
+    });
+
+    it("refuses a test delivery for a paused subscription with 409", async () => {
+      const { db, bus, server } = makeServer();
+      await seed(db, { status: "paused" });
+      const res = await server.getSubscriptionTestHandler()({
+        method: "POST",
+        path: "/eep/subscriptions/sub_test_1/test",
+        headers: {},
+        params: { subscriptionId: "sub_test_1" }
+      });
+      expect(res.status).toBe(409);
+      expect(bus.published).toEqual([]);
+    });
+
+    it("returns 404 for a test delivery on an unknown subscription", async () => {
+      const { bus, server } = makeServer();
+      const res = await server.getSubscriptionTestHandler()({
+        method: "POST",
+        path: "/eep/subscriptions/nope/test",
+        headers: {},
+        params: { subscriptionId: "nope" }
+      });
+      expect(res.status).toBe(404);
+      expect(bus.published).toEqual([]);
     });
   });
 

--- a/packages/@eep-dev/middleware/src/core/eep-server.ts
+++ b/packages/@eep-dev/middleware/src/core/eep-server.ts
@@ -10,6 +10,7 @@ import {
   type ProofVerifier
 } from "@eep-dev/gates";
 import { SSRFError, validateEventTypePattern, validateSSRF } from "@eep-dev/validator";
+import { TEST_DELIVERY_EVENT_TYPE } from "./request-handler.js";
 import type {
   AuthAdapter,
   CloudEvent,
@@ -386,6 +387,149 @@ export class EEPServer {
     };
   }
 
+  /**
+   * `GET /eep/subscriptions` — list the caller's subscriptions (§5.1.1).
+   *
+   * `delivery_secret` is stripped: it is disclosed exactly once, in the
+   * creation response.
+   */
+  getSubscriptionListHandler(): RequestHandler {
+    return async () => {
+      const subscriptions = await this.dbAdapter.listSubscriptions();
+      const safe = subscriptions.map(({ delivery_secret: _secret, ...rest }) => rest);
+      return { status: 200, body: { subscriptions: safe, count: safe.length } };
+    };
+  }
+
+  /**
+   * `POST /eep/subscriptions/:subscriptionId/pause` — stop delivering to an
+   * `active` subscription without cancelling it (§5.1.1, §10).
+   */
+  getSubscriptionPauseHandler(): RequestHandler {
+    return async (request) => {
+      const subscriptionId = request.params?.subscriptionId;
+      if (!subscriptionId) {
+        return {
+          status: 400,
+          body: { error: "invalid_request", message: "subscription_id is required" }
+        };
+      }
+      const subscription = await this.dbAdapter.getSubscription(subscriptionId);
+      if (!subscription) {
+        return {
+          status: 404,
+          body: { error: "not_found", message: `subscription ${subscriptionId} does not exist` }
+        };
+      }
+      if (subscription.status === "paused") {
+        return {
+          status: 409,
+          body: { error: "conflict", message: `subscription ${subscriptionId} is already paused` }
+        };
+      }
+      await this.dbAdapter.updateSubscription(subscriptionId, { status: "paused" });
+      const updated = await this.dbAdapter.getSubscription(subscriptionId);
+      const { delivery_secret: _secret, ...safe } = updated ?? subscription;
+      return { status: 200, body: { ...safe, status: "paused" } };
+    };
+  }
+
+  /**
+   * `POST /eep/subscriptions/:subscriptionId/resume` — move a `paused`
+   * subscription back to `active` and clear its failure counter (§5.1.1, §10).
+   */
+  getSubscriptionResumeHandler(): RequestHandler {
+    return async (request) => {
+      const subscriptionId = request.params?.subscriptionId;
+      if (!subscriptionId) {
+        return {
+          status: 400,
+          body: { error: "invalid_request", message: "subscription_id is required" }
+        };
+      }
+      const subscription = await this.dbAdapter.getSubscription(subscriptionId);
+      if (!subscription) {
+        return {
+          status: 404,
+          body: { error: "not_found", message: `subscription ${subscriptionId} does not exist` }
+        };
+      }
+      if (subscription.status === "active") {
+        return {
+          status: 409,
+          body: {
+            error: "conflict",
+            message: `subscription ${subscriptionId} is already active`
+          }
+        };
+      }
+      await this.dbAdapter.updateSubscription(subscriptionId, {
+        status: "active",
+        failure_count: 0
+      });
+      const updated = await this.dbAdapter.getSubscription(subscriptionId);
+      const { delivery_secret: _secret, ...safe } = updated ?? subscription;
+      return { status: 200, body: { ...safe, status: "active", failure_count: 0 } };
+    };
+  }
+
+  /**
+   * `POST /eep/subscriptions/:subscriptionId/test` — enqueue a synthetic,
+   * fully signed delivery to the subscription's registered `delivery_url`
+   * (§5.1.1).
+   *
+   * This is what makes a publisher's delivery path independently checkable:
+   * `@eep-dev/compliance-cli` calls it to verify Standard Webhooks headers
+   * and HMAC correctness without waiting for organic traffic. The event is
+   * published on the normal event bus; `WebhookDispatcher` routes
+   * `com.eep.subscription.test` to the single subscription named in
+   * `data.subscription_id` rather than fanning it out by `event_types`.
+   */
+  getSubscriptionTestHandler(): RequestHandler {
+    return async (request) => {
+      const subscriptionId = request.params?.subscriptionId;
+      if (!subscriptionId) {
+        return {
+          status: 400,
+          body: { error: "invalid_request", message: "subscription_id is required" }
+        };
+      }
+      const subscription = await this.dbAdapter.getSubscription(subscriptionId);
+      if (!subscription) {
+        return {
+          status: 404,
+          body: { error: "not_found", message: `subscription ${subscriptionId} does not exist` }
+        };
+      }
+      if (subscription.status !== "active") {
+        return {
+          status: 409,
+          body: {
+            error: "conflict",
+            message: `subscription ${subscriptionId} is ${subscription.status}; test deliveries require an active subscription`
+          }
+        };
+      }
+
+      const event: CloudEvent = {
+        id: `evt_test_${randomBytes(8).toString("hex")}`,
+        type: TEST_DELIVERY_EVENT_TYPE,
+        source: this.did,
+        time: new Date().toISOString(),
+        data: {
+          subscription_id: subscriptionId,
+          message: "EEP synthetic test delivery — no state changed."
+        }
+      };
+      await this.eventBusAdapter.publish(event);
+
+      return {
+        status: 202,
+        body: { status: "accepted", subscription_id: subscriptionId, event_id: event.id }
+      };
+    };
+  }
+
   getUnsubscribeHandler(): RequestHandler {
     return async (request) => {
       const subscriptionId = request.params?.subscriptionId;
@@ -454,9 +598,22 @@ export class EEPServer {
       { method: "GET", path: "/healthz", operationId: "health", handler: this.getHealthHandler() },
       { method: "GET", path: "/eep/stream", operationId: "stream", handler: this.getSSEHandler() },
       { method: "GET", path: "/eep/content/:resourcePath", operationId: "gatedContent", handler: this.getGatedResourceHandler() },
+      // Subscription resource per SPECIFICATION.md §5.1.1. Creation stays on
+      // `POST /eep/subscribe` because that URL is what the manifest advertises
+      // as `layers.layer2_webhook` and what the `rel="subscribe"` Link header
+      // points at. Every member operation lives under `/eep/subscriptions`.
       { method: "POST", path: "/eep/subscribe", operationId: "subscribe", handler: this.getSubscribeHandler() },
-      { method: "GET", path: "/eep/subscribe/:subscriptionId", operationId: "subscriptionStatus", handler: this.getSubscriptionStatusHandler() },
-      { method: "DELETE", path: "/eep/subscribe/:subscriptionId", operationId: "unsubscribe", handler: this.getUnsubscribeHandler() },
+      { method: "GET", path: "/eep/subscriptions", operationId: "listSubscriptions", handler: this.getSubscriptionListHandler() },
+      { method: "GET", path: "/eep/subscriptions/:subscriptionId", operationId: "subscriptionStatus", handler: this.getSubscriptionStatusHandler() },
+      { method: "DELETE", path: "/eep/subscriptions/:subscriptionId", operationId: "unsubscribe", handler: this.getUnsubscribeHandler() },
+      { method: "POST", path: "/eep/subscriptions/:subscriptionId/pause", operationId: "pauseSubscription", handler: this.getSubscriptionPauseHandler() },
+      { method: "POST", path: "/eep/subscriptions/:subscriptionId/resume", operationId: "resumeSubscription", handler: this.getSubscriptionResumeHandler() },
+      { method: "POST", path: "/eep/subscriptions/:subscriptionId/test", operationId: "testSubscriptionDelivery", handler: this.getSubscriptionTestHandler() },
+
+      // Deprecated 0.1.x aliases for the member operations, which shipped
+      // under `/eep/subscribe/:id` before §5.1.1 existed. Remove at 0.2.
+      { method: "GET", path: "/eep/subscribe/:subscriptionId", operationId: "subscriptionStatusDeprecated", handler: this.getSubscriptionStatusHandler() },
+      { method: "DELETE", path: "/eep/subscribe/:subscriptionId", operationId: "unsubscribeDeprecated", handler: this.getUnsubscribeHandler() },
       { method: "GET", path: "/eep/audit-log", operationId: "auditLog", handler: this.getAuditLogHandler() },
       { method: "GET", path: "/eep/pulse", operationId: "pulseUpgrade", handler: this.getPulseUpgradeHandler() }
     ];

--- a/packages/@eep-dev/middleware/src/core/request-handler.ts
+++ b/packages/@eep-dev/middleware/src/core/request-handler.ts
@@ -26,6 +26,14 @@ export type RouteDefinition = {
   operationId: string;
 };
 
+/**
+ * Event type emitted by `POST /eep/subscriptions/:id/test` (SPECIFICATION.md
+ * §5.1.1). `WebhookDispatcher` routes it to the single subscription named in
+ * `data.subscription_id` instead of fanning it out by `event_types`, so a
+ * conformance probe can exercise the signed delivery path on demand.
+ */
+export const TEST_DELIVERY_EVENT_TYPE = "com.eep.subscription.test";
+
 export type SubscriptionRecord = {
   subscription_id: string;
   source_did: string;

--- a/packages/@eep-dev/middleware/src/dispatcher/webhook-dispatcher.test.ts
+++ b/packages/@eep-dev/middleware/src/dispatcher/webhook-dispatcher.test.ts
@@ -3,6 +3,7 @@ import { EEPSigner } from "@eep-dev/signer";
 import { WebhookDispatcher, DEFAULT_RETRY_SCHEDULE_MS, type WebhookHttpClient } from "./webhook-dispatcher.js";
 import { InMemoryDBAdapter } from "../db/in-memory.js";
 import { InMemoryEventBusAdapter } from "../event-bus/in-memory.js";
+import { TEST_DELIVERY_EVENT_TYPE } from "../core/request-handler.js";
 import type { CloudEvent, SubscriptionRecord } from "../core/request-handler.js";
 
 const SECRET = "test-secret-abcdefghij";
@@ -56,6 +57,86 @@ const NO_DELAY = [0];
 describe("WebhookDispatcher", () => {
   it("uses the spec's 7-attempt retry schedule by default", () => {
     expect(DEFAULT_RETRY_SCHEDULE_MS).toEqual([0, 5_000, 30_000, 120_000, 900_000, 3_600_000, 21_600_000]);
+  });
+
+  // SPECIFICATION.md §5.1.1: a synthetic test delivery is addressed to ONE
+  // subscription. It must reach that subscriber even though
+  // `com.eep.subscription.test` matches none of their `event_types`, and it
+  // must not fan out to anyone else.
+  describe("test deliveries (§5.1.1)", () => {
+    const testEvent = (subscriptionId: string) =>
+      event({
+        id: "evt_test_1",
+        type: TEST_DELIVERY_EVENT_TYPE,
+        data: { subscription_id: subscriptionId }
+      });
+
+    it("delivers to the addressed subscription despite no event_types match", async () => {
+      const db = new InMemoryDBAdapter();
+      await db.saveSubscription(subscription({ subscription_id: "sub_target" }));
+      const { client, calls } = mockClient([200]);
+      const dispatcher = new WebhookDispatcher({ db, httpClient: client, retryScheduleMs: NO_DELAY });
+
+      const results = await dispatcher.dispatch(testEvent("sub_target"));
+
+      expect(results).toHaveLength(1);
+      expect(results[0]?.delivered).toBe(true);
+      expect(calls).toHaveLength(1);
+
+      // Signed exactly like production traffic — that is what makes the
+      // endpoint usable as a conformance probe.
+      const { headers, body } = calls[0]!;
+      expect(
+        new EEPSigner(SECRET).verify(
+          headers["webhook-id"]!,
+          headers["webhook-timestamp"]!,
+          headers["webhook-signature"]!,
+          body
+        )
+      ).toBe(true);
+    });
+
+    it("does not fan out to other subscriptions", async () => {
+      const db = new InMemoryDBAdapter();
+      await db.saveSubscription(subscription({ subscription_id: "sub_target" }));
+      await db.saveSubscription(
+        subscription({ subscription_id: "sub_bystander", callback_url: "https://other.example/hooks" })
+      );
+      const { client, calls } = mockClient([200]);
+      const dispatcher = new WebhookDispatcher({ db, httpClient: client, retryScheduleMs: NO_DELAY });
+
+      const results = await dispatcher.dispatch(testEvent("sub_target"));
+
+      expect(results).toHaveLength(1);
+      expect(calls).toHaveLength(1);
+      expect(calls[0]?.url).toBe("https://agent.example/hooks/eep");
+    });
+
+    it("delivers nothing when the addressed subscription does not exist", async () => {
+      const db = new InMemoryDBAdapter();
+      await db.saveSubscription(subscription({ subscription_id: "sub_target" }));
+      const { client, calls } = mockClient([200]);
+      const dispatcher = new WebhookDispatcher({ db, httpClient: client, retryScheduleMs: NO_DELAY });
+
+      const results = await dispatcher.dispatch(testEvent("sub_missing"));
+
+      expect(results).toHaveLength(0);
+      expect(calls).toHaveLength(0);
+    });
+
+    it("ignores a malformed test event with no subscription_id", async () => {
+      const db = new InMemoryDBAdapter();
+      await db.saveSubscription(subscription({ subscription_id: "sub_target" }));
+      const { client, calls } = mockClient([200]);
+      const dispatcher = new WebhookDispatcher({ db, httpClient: client, retryScheduleMs: NO_DELAY });
+
+      const results = await dispatcher.dispatch(
+        event({ id: "evt_test_2", type: TEST_DELIVERY_EVENT_TYPE, data: {} })
+      );
+
+      expect(results).toHaveLength(0);
+      expect(calls).toHaveLength(0);
+    });
   });
 
   it("delivers a matching event with verifiable Standard Webhooks headers", async () => {

--- a/packages/@eep-dev/middleware/src/dispatcher/webhook-dispatcher.ts
+++ b/packages/@eep-dev/middleware/src/dispatcher/webhook-dispatcher.ts
@@ -1,5 +1,6 @@
 import { EEPSigner } from "@eep-dev/signer";
 import { matchesAnyPattern } from "@eep-dev/validator";
+import { TEST_DELIVERY_EVENT_TYPE } from "../core/request-handler.js";
 import type {
   CloudEvent,
   DBAdapter,
@@ -167,13 +168,24 @@ export class WebhookDispatcher {
   }
 
   private isTarget(sub: SubscriptionRecord, event: CloudEvent): boolean {
-    return (
+    const deliverable =
       sub.delivery_method === "webhook" &&
       sub.status === "active" &&
       typeof sub.callback_url === "string" &&
-      sub.callback_url.length > 0 &&
-      matchesAnyPattern(event.type, sub.event_types)
-    );
+      sub.callback_url.length > 0;
+    if (!deliverable) return false;
+
+    // A synthetic test delivery is addressed to ONE subscription and must not
+    // fan out. It also deliberately bypasses `event_types`: the whole point is
+    // to exercise the signed delivery path for a subscriber whose patterns
+    // would never match `com.eep.subscription.test`. See SPECIFICATION.md
+    // §5.1.1.
+    if (event.type === TEST_DELIVERY_EVENT_TYPE) {
+      const target = (event.data as { subscription_id?: unknown } | undefined)?.subscription_id;
+      return typeof target === "string" && target === sub.subscription_id;
+    }
+
+    return matchesAnyPattern(event.type, sub.event_types);
   }
 
   private async deliverWithRetry(event: CloudEvent, sub: SubscriptionRecord): Promise<DeliveryResult> {

--- a/packages/@eep-dev/middleware/src/index.ts
+++ b/packages/@eep-dev/middleware/src/index.ts
@@ -1,4 +1,5 @@
 export { EEPServer, type EEPServerOptions } from "./core/eep-server.js";
+export { TEST_DELIVERY_EVENT_TYPE } from "./core/request-handler.js";
 export type {
   AuthAdapter,
   CloudEvent,


### PR DESCRIPTION
## Summary

**PR 2 of a stacked series.** Base is #93 — review that first; GitHub will retarget this to `main` when #93 merges. **Not for merge without review.**

The subscription resource is addressed **five different ways** across the repo, and two of those paths are load-bearing for conformance:

| Source | Path |
|---|---|
| spec §5.1 | `POST /eep/subscribe` |
| spec §10 | `POST /subscribe` |
| spec §10 | `POST /subscriptions/:id/resume` |
| middleware | `GET\|DELETE /eep/subscribe/:id` |
| compliance-cli | `GET /eep/subscriptions` |
| compliance-cli | `POST /eep/subscriptions/:id/test` |

### The consequence

`POST /eep/subscriptions/:id/test` is how the **Core-tier probe triggers a delivery** in order to verify Standard Webhooks headers and HMAC correctness. It is specified nowhere and implemented nowhere — not in the middleware route table, not in either reference implementation.

And it fails *silently*. `fetch` rejects only on a transport error, so a 404 resolves normally, the runner sleeps 5s, receives nothing, and reports:

```
❌ Webhook delivery received: no webhook received within 5s
```

An implementer reads that as "my dispatcher is broken" and goes hunting for a bug that was never theirs. `GET /eep/subscriptions` (Standard-tier rate-limit probe) has the same shape — asserted against a 404.

### The paths here are not new

`docs/guides/how-to-subscribe.md` has documented `/eep/subscriptions/{id}` with `pause`, `resume`, `test` and `DELETE` **since v0.1**, and `delivery_guarantees.md` references the same collection for delivery logs. **The guide was right; the spec and middleware were the outliers.** This PR makes the guide's API normative rather than inventing anything.

Creation stays on `POST /eep/subscribe` — that URL is what the manifest advertises as `layers.layer2_webhook` and what the `rel="subscribe"` Link header points at, so moving it would break every deployed publisher.

## What changed

**Spec**
- New **§5.1.1**: the subscription resource, its member operations, status codes and scopes; `delivery_secret` never re-exposed; `404`-not-`403` for another subscriber's id so the collection can't be enumerated; test-delivery semantics (`202`, signed exactly like production traffic, `409` when not `active`).
- **§10** lifecycle uses the canonical paths and now defines what a "failed delivery" *is* — a fully exhausted §5.4 retry schedule, counter reset on the next 2xx. That ambiguity (7 retry attempts vs. "5 consecutive failures") was previously resolvable only by reading the CHANGELOG.
- **§14.2** conformance line points at §5.1.1 instead of claiming a lifecycle the spec never wrote down.

**Middleware**
- Serves list / pause / resume / test alongside status and unsubscribe, all under `/eep/subscriptions`; `/eep/subscribe/:id` kept as deprecated `0.1.x` aliases.
- `WebhookDispatcher` routes `com.eep.subscription.test` to the single subscription named in `data.subscription_id` instead of fanning out by `event_types` — a test delivery must reach a subscriber whose patterns would never match it, and must reach nobody else.

**compliance-cli**
- The trigger reports its own outcome and names the missing endpoint on a 404.
- Downstream signature probes **SKIP** rather than **FAIL** when nothing could be triggered: the publisher's signing is untested, not proven broken.

## Scope

- [x] Spec / schema only
- [x] TypeScript package(s)
- [ ] Python package(s)
- [x] Tests / CI
- [x] Docs / examples

## Checklist

- [x] I read CONTRIBUTING.md and CODE_OF_CONDUCT.md.
- [x] Tests added or updated where appropriate.
- [x] **Breaking change?** Additive for publishers. Middleware consumers see new routes; the old member paths still work as deprecated aliases through `0.1.x`. Publishers that never implemented `/test` will now see an explicit, actionable conformance failure where they previously saw a misleading one.
- [x] Documentation updated for user-visible behavior.

## Verification

| Suite | Result |
|---|---|
| `@eep-dev/middleware` | 109 passed (was 93) |
| `@eep-dev/compliance-cli` | 57 passed |
| `tests/` (vitest) | 164 passed |
| `npx tsc --noEmit` (middleware, compliance-cli) | clean |
| `node scripts/codegen-schema-types.mjs --check` | no drift |

## Notes for reviewers

**Design decision worth confirming:** I aligned the spec and middleware to the *guides*, rather than aligning the guides to the middleware. The alternative — standardising on `/eep/subscribe/:id` — would have required rewriting `how-to-subscribe.md` and `delivery_guarantees.md` and would leave the CLI's existing paths wrong. Happy to flip it if you'd rather.

`delivery_guarantees.md:92` also references `GET /eep/subscriptions/:id/delivery-log`, which is still unspecified. That belongs with the webhook backfill/redelivery work (audit finding B1) and is deliberately **not** in this PR.

Python middleware parity for the new handlers is not included here — flagging it rather than silently skipping it.