### PR TITLE
feat(spec,middleware): publisher-side subscription filters

### DIFF
--- a/docs/current/SPECIFICATION.md
+++ b/docs/current/SPECIFICATION.md
@@ -436,6 +436,54 @@ This table makes normative the API that [How to subscribe](../guides/how-to-subs
 
 > **Compatibility note (v0.1).** Reference middleware released before this section served the member operations under `/eep/subscribe/{subscription_id}`. Implementations SHOULD continue to accept those paths as deprecated aliases through the `0.1.x` line and SHOULD advertise only the `/eep/subscriptions` forms.
 
+#### 5.1.3 Subscription filters (normative)
+
+`event_types` selects by type, with a wildcard permitted only in the final
+segment. That is the whole of the filtering EEP offered, so a subscriber
+interested in one field of one object still received every event of that type
+and discarded the rest — after paying full delivery cost. For an agent that
+cost is tokens, which is the "context bloat" this protocol exists to remove.
+
+Publishers SHOULD accept an optional `filter` on the subscription request and
+MUST evaluate it **before** delivering:
+
+```json
+{
+  "event_types": ["com.example.entity.updated"],
+  "filter": {
+    "match": "all",
+    "conditions": [
+      { "path": "subject", "op": "prefix", "value": "listing/" },
+      { "path": "data.status", "op": "in", "value": ["published", "archived"] }
+    ]
+  }
+}
+```
+
+- `path` is a dotted path into the **envelope**, so it can address `subject`
+  (§7.1), any `eep_*` attribute, or into `data`.
+- `match` is `all` or `any`. Operators: `eq`, `ne`, `in`, `nin`, `prefix`,
+  `exists`, `gt`, `lt`.
+- A filter **narrows** what `event_types` already selected; it never widens.
+  An event that fails the filter is not delivered and does not count toward
+  the subscription's failure counter.
+
+**The language is deliberately not Turing-complete, and has no regex
+operator.** A filter is evaluated by the publisher, on the delivery hot path,
+against every candidate event — so a richer language would let a subscriber
+hand the publisher an expensive expression to run at the publisher's expense.
+Publishers MUST bound conditions (20) and path depth (8), and MUST reject a
+filter that exceeds them.
+
+Publishers MUST reject a malformed filter at subscription time with `400`
+rather than accepting it and ignoring it. A subscriber that believes it is
+filtering, but is not, receives traffic it thought it had asked to be spared,
+and cannot detect the difference from its side.
+
+Filters are a delivery optimisation, not an access control. A filter MUST NOT
+be able to widen what the subscriber's tier already grants (§3.4), and
+publishers MUST apply gates before filters.
+
 #### 5.1.2 Event history and redelivery (normative)
 
 SSE subscribers recover missed events with `Last-Event-ID` (§4.3, minimum 24h

--- a/packages/@eep-dev/middleware/src/core/eep-server.ts
+++ b/packages/@eep-dev/middleware/src/core/eep-server.ts
@@ -12,6 +12,7 @@ import {
 } from "@eep-dev/gates";
 import { SSRFError, validateEventTypePattern, validateSSRF } from "@eep-dev/validator";
 import { withConditional } from "./conditional.js";
+import { validateFilter, FilterValidationError, type EventFilter } from "./event-filter.js";
 import {
   InMemoryEventStore,
   RetentionWindowExceededError,
@@ -391,6 +392,22 @@ export class EEPServer {
         }
       }
 
+      // §5.1.3 — reject a malformed filter rather than accepting and ignoring
+      // it. A subscriber that believes it is filtering, but is not, receives
+      // traffic it thought it had asked to be spared and cannot tell from its
+      // own side.
+      let filter: EventFilter | undefined;
+      if (body.filter !== undefined) {
+        try {
+          filter = validateFilter(body.filter);
+        } catch (err) {
+          if (err instanceof FilterValidationError) {
+            return { status: 400, body: { error: "invalid_request", message: err.message } };
+          }
+          throw err;
+        }
+      }
+
       // A per-subscription HMAC secret used to sign webhook deliveries.
       // Returned to the subscriber once, on creation, and never again.
       const deliverySecret = deliveryMethod === "webhook" ? randomBytes(24).toString("base64url") : undefined;
@@ -412,6 +429,7 @@ export class EEPServer {
         status: "active",
         failure_count: 0,
         expires_at: expiresAt.toISOString(),
+        ...(filter ? { filter } : {}),
         delivery_secret: deliverySecret,
         metadata,
         tier,

--- a/packages/@eep-dev/middleware/src/core/event-filter.test.ts
+++ b/packages/@eep-dev/middleware/src/core/event-filter.test.ts
@@ -1,0 +1,147 @@
+import { describe, expect, it } from "vitest";
+import {
+    validateFilter,
+    eventMatchesFilter,
+    readPath,
+    FilterValidationError,
+    MAX_FILTER_CONDITIONS,
+    type EventFilter,
+} from "./event-filter.js";
+import type { CloudEvent } from "./request-handler.js";
+
+const evt = (overrides: Partial<CloudEvent> = {}): CloudEvent => ({
+    id: "evt-1",
+    type: "com.example.entity.updated",
+    source: "did:web:acme.example",
+    time: "2026-01-01T00:00:00.000Z",
+    data: { field: "bio", status: "published", score: 42 },
+    ...overrides,
+});
+
+describe("validateFilter (§5.1.3)", () => {
+    const ok: EventFilter = { match: "all", conditions: [{ path: "subject", op: "exists" }] };
+
+    it("accepts a well-formed filter", () => {
+        expect(validateFilter(ok)).toEqual(ok);
+    });
+
+    it.each([
+        ["not an object", "string"],
+        ["null", null],
+        ["missing match", { conditions: [{ path: "a", op: "exists" }] }],
+        ["bad match", { match: "some", conditions: [{ path: "a", op: "exists" }] }],
+        ["missing conditions", { match: "all" }],
+        ["empty conditions", { match: "all", conditions: [] }],
+        ["bad op", { match: "all", conditions: [{ path: "a", op: "regex" }] }],
+        ["empty path", { match: "all", conditions: [{ path: "", op: "exists" }] }],
+        ["empty path segment", { match: "all", conditions: [{ path: "a..b", op: "exists" }] }],
+    ])("rejects %s", (_label, input) => {
+        expect(() => validateFilter(input)).toThrow(FilterValidationError);
+    });
+
+    it("rejects more conditions than the bound allows", () => {
+        const conditions = Array.from({ length: MAX_FILTER_CONDITIONS + 1 }, () => ({
+            path: "a",
+            op: "exists" as const,
+        }));
+        expect(() => validateFilter({ match: "all", conditions })).toThrow(FilterValidationError);
+    });
+
+    it("rejects a path deeper than the bound allows", () => {
+        const path = Array.from({ length: 9 }, (_, i) => `s${i}`).join(".");
+        expect(() => validateFilter({ match: "all", conditions: [{ path, op: "exists" }] })).toThrow(
+            FilterValidationError
+        );
+    });
+
+    // A subscriber-supplied path must never reach a prototype lookup.
+    it.each(["__proto__", "constructor", "prototype"])("rejects a path traversing %s", (segment) => {
+        expect(() =>
+            validateFilter({ match: "all", conditions: [{ path: `data.${segment}`, op: "exists" }] })
+        ).toThrow(FilterValidationError);
+    });
+
+    it("enforces operand types per operator", () => {
+        expect(() => validateFilter({ match: "all", conditions: [{ path: "a", op: "in", value: "x" }] })).toThrow();
+        expect(() => validateFilter({ match: "all", conditions: [{ path: "a", op: "prefix", value: 1 }] })).toThrow();
+        expect(() => validateFilter({ match: "all", conditions: [{ path: "a", op: "gt", value: "1" }] })).toThrow();
+    });
+});
+
+describe("readPath", () => {
+    it("reads envelope and nested data paths", () => {
+        expect(readPath(evt({ subject: "listing/1" } as Partial<CloudEvent>), "subject")).toBe("listing/1");
+        expect(readPath(evt(), "data.status")).toBe("published");
+        expect(readPath(evt(), "type")).toBe("com.example.entity.updated");
+    });
+
+    it("returns undefined for an absent path", () => {
+        expect(readPath(evt(), "data.nope")).toBeUndefined();
+        expect(readPath(evt(), "a.b.c")).toBeUndefined();
+    });
+
+    // Even if validation were bypassed, the reader must not walk the prototype.
+    it("does not read inherited properties", () => {
+        expect(readPath(evt(), "data.toString")).toBeUndefined();
+        expect(readPath(evt(), "constructor")).toBeUndefined();
+    });
+});
+
+describe("eventMatchesFilter (§5.1.3)", () => {
+    it("matches everything when no filter is set", () => {
+        expect(eventMatchesFilter(evt(), undefined)).toBe(true);
+    });
+
+    it.each([
+        ["eq hit", { path: "data.status", op: "eq", value: "published" }, true],
+        ["eq miss", { path: "data.status", op: "eq", value: "draft" }, false],
+        ["ne hit", { path: "data.status", op: "ne", value: "draft" }, true],
+        ["in hit", { path: "data.status", op: "in", value: ["published", "archived"] }, true],
+        ["in miss", { path: "data.status", op: "in", value: ["draft"] }, false],
+        ["nin hit", { path: "data.status", op: "nin", value: ["draft"] }, true],
+        ["prefix hit", { path: "type", op: "prefix", value: "com.example." }, true],
+        ["prefix miss", { path: "type", op: "prefix", value: "org.other." }, false],
+        ["exists hit", { path: "data.field", op: "exists" }, true],
+        ["exists miss", { path: "data.absent", op: "exists" }, false],
+        ["gt hit", { path: "data.score", op: "gt", value: 10 }, true],
+        ["gt miss", { path: "data.score", op: "gt", value: 100 }, false],
+        ["lt hit", { path: "data.score", op: "lt", value: 100 }, true],
+    ])("%s", (_label, condition, expected) => {
+        expect(
+            eventMatchesFilter(evt(), { match: "all", conditions: [condition as never] })
+        ).toBe(expected);
+    });
+
+    it("requires every condition under match=all", () => {
+        const filter: EventFilter = {
+            match: "all",
+            conditions: [
+                { path: "data.status", op: "eq", value: "published" },
+                { path: "data.score", op: "gt", value: 100 },
+            ],
+        };
+        expect(eventMatchesFilter(evt(), filter)).toBe(false);
+    });
+
+    it("requires only one condition under match=any", () => {
+        const filter: EventFilter = {
+            match: "any",
+            conditions: [
+                { path: "data.status", op: "eq", value: "published" },
+                { path: "data.score", op: "gt", value: 100 },
+            ],
+        };
+        expect(eventMatchesFilter(evt(), filter)).toBe(true);
+    });
+
+    // Type-mismatched comparisons must be false, not throw: the filter runs on
+    // the publisher's delivery hot path against arbitrary payloads.
+    it("returns false rather than throwing on a type mismatch", () => {
+        expect(
+            eventMatchesFilter(evt(), { match: "all", conditions: [{ path: "data.score", op: "prefix", value: "4" }] })
+        ).toBe(false);
+        expect(
+            eventMatchesFilter(evt(), { match: "all", conditions: [{ path: "data.status", op: "gt", value: 1 }] })
+        ).toBe(false);
+    });
+});

--- a/packages/@eep-dev/middleware/src/core/event-filter.ts
+++ b/packages/@eep-dev/middleware/src/core/event-filter.ts
@@ -1,0 +1,164 @@
+/**
+ * Publisher-side subscription filters (SPECIFICATION.md §5.1.3).
+ *
+ * Filtering was `event_types` glob only, and `subscription.request.json`
+ * permits `*` solely in the final segment. A subscriber interested in one
+ * field of one object still received every event of that type and discarded
+ * the rest — after paying full delivery cost. For an LLM agent that cost is
+ * tokens, which is exactly the "context bloat" EEP claims to remove.
+ *
+ * The predicate language is deliberately small and NOT Turing-complete:
+ * a flat list of comparisons over dotted paths, combined with `all` or `any`.
+ * There is no regex operator, so a subscriber cannot hand a publisher a
+ * catastrophically backtracking pattern to evaluate on every event — the
+ * ReDoS surface that a richer language would open on the publisher's hot path
+ * simply does not exist here.
+ */
+import type { CloudEvent } from "./request-handler.js";
+
+export type FilterOperator = "eq" | "ne" | "in" | "nin" | "prefix" | "exists" | "gt" | "lt";
+
+export interface FilterCondition {
+    /** Dotted path into the event, e.g. `subject` or `data.field`. */
+    path: string;
+    op: FilterOperator;
+    /** Comparison operand. Absent for `exists`. */
+    value?: unknown;
+}
+
+export interface EventFilter {
+    /** `all` = every condition must hold; `any` = at least one. */
+    match: "all" | "any";
+    conditions: FilterCondition[];
+}
+
+/** Bounds keep evaluation cheap on the delivery hot path. */
+export const MAX_FILTER_CONDITIONS = 20;
+export const MAX_FILTER_PATH_DEPTH = 8;
+
+export class FilterValidationError extends Error {
+    constructor(message: string) {
+        super(message);
+        this.name = "FilterValidationError";
+    }
+}
+
+const OPERATORS = new Set<FilterOperator>(["eq", "ne", "in", "nin", "prefix", "exists", "gt", "lt"]);
+
+/**
+ * Validate a subscriber-supplied filter.
+ *
+ * Rejects rather than silently ignoring a malformed filter: a subscriber that
+ * believes it is filtering, but is not, receives traffic it thinks it asked to
+ * be spared — the opposite of the intent, and impossible to notice from its
+ * side.
+ */
+export function validateFilter(filter: unknown): EventFilter {
+    if (typeof filter !== "object" || filter === null) {
+        throw new FilterValidationError("filter must be an object");
+    }
+    const candidate = filter as Partial<EventFilter>;
+    if (candidate.match !== "all" && candidate.match !== "any") {
+        throw new FilterValidationError("filter.match must be 'all' or 'any'");
+    }
+    if (!Array.isArray(candidate.conditions) || candidate.conditions.length === 0) {
+        throw new FilterValidationError("filter.conditions must be a non-empty array");
+    }
+    if (candidate.conditions.length > MAX_FILTER_CONDITIONS) {
+        throw new FilterValidationError(
+            `filter.conditions exceeds the maximum of ${MAX_FILTER_CONDITIONS}`
+        );
+    }
+
+    for (const condition of candidate.conditions) {
+        if (typeof condition !== "object" || condition === null) {
+            throw new FilterValidationError("each condition must be an object");
+        }
+        const { path, op, value } = condition as FilterCondition;
+        if (typeof path !== "string" || path.length === 0) {
+            throw new FilterValidationError("condition.path must be a non-empty string");
+        }
+        const segments = path.split(".");
+        if (segments.length > MAX_FILTER_PATH_DEPTH) {
+            throw new FilterValidationError(
+                `condition.path exceeds the maximum depth of ${MAX_FILTER_PATH_DEPTH}`
+            );
+        }
+        if (segments.some((s) => s.length === 0)) {
+            throw new FilterValidationError("condition.path has an empty segment");
+        }
+        // `__proto__` / `constructor` in a subscriber-supplied path must never
+        // reach a property lookup.
+        if (segments.some((s) => s === "__proto__" || s === "constructor" || s === "prototype")) {
+            throw new FilterValidationError("condition.path may not traverse object internals");
+        }
+        if (!OPERATORS.has(op)) {
+            throw new FilterValidationError(`condition.op must be one of: ${[...OPERATORS].join(", ")}`);
+        }
+        if ((op === "in" || op === "nin") && !Array.isArray(value)) {
+            throw new FilterValidationError(`condition.value must be an array for op '${op}'`);
+        }
+        if (op === "prefix" && typeof value !== "string") {
+            throw new FilterValidationError("condition.value must be a string for op 'prefix'");
+        }
+        if ((op === "gt" || op === "lt") && typeof value !== "number") {
+            throw new FilterValidationError(`condition.value must be a number for op '${op}'`);
+        }
+    }
+
+    return { match: candidate.match, conditions: candidate.conditions as FilterCondition[] };
+}
+
+/** Read a dotted path out of an event. Returns `undefined` when absent. */
+export function readPath(event: CloudEvent, path: string): unknown {
+    let current: unknown = event;
+    for (const segment of path.split(".")) {
+        if (current === null || typeof current !== "object") return undefined;
+        if (!Object.prototype.hasOwnProperty.call(current, segment)) return undefined;
+        current = (current as Record<string, unknown>)[segment];
+    }
+    return current;
+}
+
+function evaluateCondition(event: CloudEvent, condition: FilterCondition): boolean {
+    const actual = readPath(event, condition.path);
+    switch (condition.op) {
+        case "exists":
+            return actual !== undefined;
+        case "eq":
+            return actual === condition.value;
+        case "ne":
+            return actual !== condition.value;
+        case "in":
+            return Array.isArray(condition.value) && condition.value.includes(actual);
+        case "nin":
+            return Array.isArray(condition.value) && !condition.value.includes(actual);
+        case "prefix":
+            return typeof actual === "string" && typeof condition.value === "string"
+                ? actual.startsWith(condition.value)
+                : false;
+        case "gt":
+            return typeof actual === "number" && typeof condition.value === "number"
+                ? actual > condition.value
+                : false;
+        case "lt":
+            return typeof actual === "number" && typeof condition.value === "number"
+                ? actual < condition.value
+                : false;
+        default:
+            return false;
+    }
+}
+
+/**
+ * Does `event` satisfy `filter`?
+ *
+ * A subscription with no filter matches everything its `event_types` already
+ * selected — the filter narrows, it never widens.
+ */
+export function eventMatchesFilter(event: CloudEvent, filter: EventFilter | undefined): boolean {
+    if (!filter) return true;
+    return filter.match === "all"
+        ? filter.conditions.every((c) => evaluateCondition(event, c))
+        : filter.conditions.some((c) => evaluateCondition(event, c));
+}

--- a/packages/@eep-dev/middleware/src/core/request-handler.ts
+++ b/packages/@eep-dev/middleware/src/core/request-handler.ts
@@ -1,3 +1,4 @@
+import type { EventFilter } from "./event-filter.js";
 import type { GateProof } from "@eep-dev/gates";
 
 export type HTTPMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
@@ -80,6 +81,11 @@ export type SubscriptionRecord = {
   delivery_secret?: string;
   /** Subscriber-defined metadata (passed through, not interpreted). */
   metadata?: Record<string, string>;
+  /**
+   * Publisher-side content filter (SPECIFICATION.md §5.1.3). Narrows what
+   * `event_types` selected; never widens it.
+   */
+  filter?: EventFilter;
   /** Requested access tier; matched against gate config on delivery. */
   tier?: string;
   created_at: string;

--- a/packages/@eep-dev/middleware/src/dispatcher/webhook-dispatcher.test.ts
+++ b/packages/@eep-dev/middleware/src/dispatcher/webhook-dispatcher.test.ts
@@ -59,6 +59,64 @@ describe("WebhookDispatcher", () => {
     expect(DEFAULT_RETRY_SCHEDULE_MS).toEqual([0, 5_000, 30_000, 120_000, 900_000, 3_600_000, 21_600_000]);
   });
 
+  // SPECIFICATION.md §5.1.3 — the filter narrows what event_types already
+  // selected. Before this, a subscriber interested in one field of one object
+  // still received every event of that type and discarded the rest, after
+  // paying full delivery cost.
+  describe("subscription filters (§5.1.3)", () => {
+    const dispatchWith = async (
+      filter: Parameters<typeof subscription>[0]["filter"],
+      overrides: Partial<CloudEvent> = {}
+    ) => {
+      const db = new InMemoryDBAdapter();
+      await db.saveSubscription(subscription({ filter }));
+      const { client, calls } = mockClient([200]);
+      const dispatcher = new WebhookDispatcher({ db, httpClient: client, retryScheduleMs: NO_DELAY });
+      const results = await dispatcher.dispatch(event({ data: { status: "published" }, ...overrides }));
+      return { results, calls };
+    };
+
+    it("delivers an event that satisfies the filter", async () => {
+      const { calls } = await dispatchWith({
+        match: "all",
+        conditions: [{ path: "data.status", op: "eq", value: "published" }]
+      });
+      expect(calls).toHaveLength(1);
+    });
+
+    it("does not deliver an event that fails the filter", async () => {
+      const { results, calls } = await dispatchWith({
+        match: "all",
+        conditions: [{ path: "data.status", op: "eq", value: "draft" }]
+      });
+      expect(calls).toHaveLength(0);
+      // Not a delivery failure — the event was never a candidate, so it must
+      // not count toward the subscription's failure counter.
+      expect(results).toHaveLength(0);
+    });
+
+    it("delivers everything when no filter is set", async () => {
+      const { calls } = await dispatchWith(undefined);
+      expect(calls).toHaveLength(1);
+    });
+
+    // The filter narrows; it never widens. An event whose type was not
+    // selected stays undelivered however permissive the filter is.
+    it("cannot widen beyond event_types", async () => {
+      const db = new InMemoryDBAdapter();
+      await db.saveSubscription(
+        subscription({
+          event_types: ["com.example.other"],
+          filter: { match: "any", conditions: [{ path: "id", op: "exists" }] }
+        })
+      );
+      const { client, calls } = mockClient([200]);
+      const dispatcher = new WebhookDispatcher({ db, httpClient: client, retryScheduleMs: NO_DELAY });
+      await dispatcher.dispatch(event());
+      expect(calls).toHaveLength(0);
+    });
+  });
+
   // SPECIFICATION.md §7.1 — W3C Trace Context is mirrored into HTTP headers
   // per the CloudEvents Distributed Tracing extension. EEP is multi-hop by
   // design, and without propagation the causal chain breaks at every

--- a/packages/@eep-dev/middleware/src/dispatcher/webhook-dispatcher.ts
+++ b/packages/@eep-dev/middleware/src/dispatcher/webhook-dispatcher.ts
@@ -2,6 +2,7 @@ import { EEPSigner } from "@eep-dev/signer";
 import { matchesAnyPattern } from "@eep-dev/validator";
 import { TEST_DELIVERY_EVENT_TYPE } from "../core/request-handler.js";
 import type { EventStore } from "../core/event-store.js";
+import { eventMatchesFilter } from "../core/event-filter.js";
 import type {
   CloudEvent,
   DBAdapter,
@@ -219,7 +220,12 @@ export class WebhookDispatcher {
       return typeof target === "string" && target === sub.subscription_id;
     }
 
-    return matchesAnyPattern(event.type, sub.event_types);
+    if (!matchesAnyPattern(event.type, sub.event_types)) return false;
+
+    // §5.1.3 — the filter narrows what `event_types` already selected. An
+    // event that fails it is simply not delivered, and does not count toward
+    // the subscription's failure counter.
+    return eventMatchesFilter(event, sub.filter);
   }
 
   /**

--- a/packages/@eep-dev/middleware/src/index.ts
+++ b/packages/@eep-dev/middleware/src/index.ts
@@ -48,6 +48,18 @@ export { RedisEventBusAdapter, type RedisClientLike } from "./event-bus/redis.js
 export { KafkaEventBusAdapter, type KafkaProducerLike, type KafkaConsumerLike } from "./event-bus/kafka.js";
 
 export {
+  validateFilter,
+  eventMatchesFilter,
+  readPath,
+  FilterValidationError,
+  MAX_FILTER_CONDITIONS,
+  MAX_FILTER_PATH_DEPTH,
+  type EventFilter,
+  type FilterCondition,
+  type FilterOperator
+} from "./core/event-filter.js";
+
+export {
   InMemoryEventStore,
   RetentionWindowExceededError,
   MIN_EVENT_RETENTION_MS,

--- a/schemas/v0.1/subscription.request.json
+++ b/schemas/v0.1/subscription.request.json
@@ -35,6 +35,66 @@
         ]
       }
     },
+    "filter": {
+      "type": "object",
+      "description": "Optional publisher-side content filter (SPECIFICATION.md \u00a75.1.3). Narrows what `event_types` already selected; it never widens. Deliberately not Turing-complete and with no regex operator, so a subscriber cannot hand the publisher an expensive pattern to evaluate on every delivery.",
+      "required": [
+        "match",
+        "conditions"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "match": {
+          "type": "string",
+          "description": "'all' requires every condition to hold; 'any' requires at least one.",
+          "enum": [
+            "all",
+            "any"
+          ]
+        },
+        "conditions": {
+          "type": "array",
+          "minItems": 1,
+          "maxItems": 20,
+          "items": {
+            "type": "object",
+            "required": [
+              "path",
+              "op"
+            ],
+            "additionalProperties": false,
+            "properties": {
+              "path": {
+                "type": "string",
+                "description": "Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.",
+                "pattern": "^[A-Za-z0-9_-]+(\\.[A-Za-z0-9_-]+){0,7}$",
+                "examples": [
+                  "subject",
+                  "data.field",
+                  "eep_actor_type"
+                ]
+              },
+              "op": {
+                "type": "string",
+                "enum": [
+                  "eq",
+                  "ne",
+                  "in",
+                  "nin",
+                  "prefix",
+                  "exists",
+                  "gt",
+                  "lt"
+                ]
+              },
+              "value": {
+                "description": "Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'."
+              }
+            }
+          }
+        }
+      }
+    },
     "delivery_method": {
       "type": "string",
       "description": "How events should be delivered to the subscriber.",

--- a/tests/conformance-fixtures/manifest.json
+++ b/tests/conformance-fixtures/manifest.json
@@ -235,6 +235,28 @@
       "asserts_valid": false
     },
     {
+      "id": "subscription-filter-valid",
+      "category": "subscription",
+      "tier": "Standard",
+      "spec_section": "\u00a75.1.3 Subscription filters",
+      "schema": "schemas/v0.1/subscription.request.json",
+      "input": "subscription/filter-valid.input.json",
+      "expected": "subscription/filter-valid.expected.json",
+      "shape": "json-pair",
+      "asserts_valid": true
+    },
+    {
+      "id": "subscription-filter-unknown-operator",
+      "category": "subscription",
+      "tier": "Standard",
+      "spec_section": "\u00a75.1.3 Subscription filters",
+      "schema": "schemas/v0.1/subscription.request.json",
+      "input": "subscription/filter-unknown-operator.input.json",
+      "expected": "subscription/filter-unknown-operator.expected.json",
+      "shape": "json-pair",
+      "asserts_valid": false
+    },
+    {
       "id": "discovery-crosswalk-host-bundle",
       "category": "discovery",
       "tier": "Informative",

--- a/tests/conformance-fixtures/subscription/filter-unknown-operator.expected.json
+++ b/tests/conformance-fixtures/subscription/filter-unknown-operator.expected.json
@@ -1,0 +1,4 @@
+{
+  "valid": false,
+  "reason": "the filter language has no regex operator; a subscriber must not be able to hand the publisher a backtracking pattern to evaluate on every event"
+}

--- a/tests/conformance-fixtures/subscription/filter-unknown-operator.input.json
+++ b/tests/conformance-fixtures/subscription/filter-unknown-operator.input.json
@@ -1,0 +1,18 @@
+{
+  "source_did": "did:web:test.eep.dev:u:alice",
+  "event_types": [
+    "com.example.entity.updated"
+  ],
+  "delivery_method": "webhook",
+  "delivery_url": "https://agent.example.com/hooks/eep",
+  "filter": {
+    "match": "all",
+    "conditions": [
+      {
+        "path": "data.status",
+        "op": "regex",
+        "value": "^(a+)+$"
+      }
+    ]
+  }
+}

--- a/tests/conformance-fixtures/subscription/filter-valid.expected.json
+++ b/tests/conformance-fixtures/subscription/filter-valid.expected.json
@@ -1,0 +1,4 @@
+{
+  "valid": true,
+  "reason": "publisher-side content filter (SPECIFICATION.md \u00a75.1.3)"
+}

--- a/tests/conformance-fixtures/subscription/filter-valid.input.json
+++ b/tests/conformance-fixtures/subscription/filter-valid.input.json
@@ -1,0 +1,26 @@
+{
+  "source_did": "did:web:test.eep.dev:u:alice",
+  "event_types": [
+    "com.example.entity.updated"
+  ],
+  "delivery_method": "webhook",
+  "delivery_url": "https://agent.example.com/hooks/eep",
+  "filter": {
+    "match": "all",
+    "conditions": [
+      {
+        "path": "subject",
+        "op": "prefix",
+        "value": "listing/"
+      },
+      {
+        "path": "data.status",
+        "op": "in",
+        "value": [
+          "published",
+          "archived"
+        ]
+      }
+    ]
+  }
+}

--- a/tests/types/eep-schemas.d.ts
+++ b/tests/types/eep-schemas.d.ts
@@ -2695,6 +2695,2790 @@ export interface EEPSubscriptionRequest {
    */
   event_types: [string, ...string[]];
   /**
+   * Optional publisher-side content filter (SPECIFICATION.md §5.1.3). Narrows what `event_types` already selected; it never widens. Deliberately not Turing-complete and with no regex operator, so a subscriber cannot hand the publisher an expensive pattern to evaluate on every delivery.
+   */
+  filter?: {
+    /**
+     * 'all' requires every condition to hold; 'any' requires at least one.
+     */
+    match: 'all' | 'any';
+    /**
+     * @minItems 1
+     * @maxItems 20
+     */
+    conditions:
+      | [
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          }
+        ]
+      | [
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          }
+        ]
+      | [
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          }
+        ]
+      | [
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          }
+        ]
+      | [
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          }
+        ]
+      | [
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          }
+        ]
+      | [
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          }
+        ]
+      | [
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          }
+        ]
+      | [
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          }
+        ]
+      | [
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          }
+        ]
+      | [
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          }
+        ]
+      | [
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          }
+        ]
+      | [
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          }
+        ]
+      | [
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          }
+        ]
+      | [
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          }
+        ]
+      | [
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          }
+        ]
+      | [
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          }
+        ]
+      | [
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          }
+        ]
+      | [
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          }
+        ]
+      | [
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          },
+          {
+            /**
+             * Dotted path into the event envelope, e.g. 'subject' or 'data.field'. At most 8 segments; may not traverse object internals.
+             */
+            path: string;
+            op: 'eq' | 'ne' | 'in' | 'nin' | 'prefix' | 'exists' | 'gt' | 'lt';
+            /**
+             * Operand. An array for 'in'/'nin', a string for 'prefix', a number for 'gt'/'lt', and absent for 'exists'.
+             */
+            value?: {
+              [k: string]: unknown | undefined;
+            };
+          }
+        ];
+  };
+  /**
    * How events should be delivered to the subscriber.
    */
   delivery_method: 'webhook' | 'sse';


### PR DESCRIPTION
## Summary

**PR 15 of a stacked series.** Base is #106. **Not for merge without review.**

Filtering was `event_types` glob only — and `subscription.request.json` permits `*` **solely in the final segment**. A subscriber interested in one field of one object still received every event of that type and discarded the rest, *after paying full delivery cost*. For an LLM agent that cost is tokens.

`docs/strategy/unmet-needs-map.md` answers the "context bloat" pain with *"Subscribers choose **what** and **when**"*. **The mechanism was thinner than the claim.**

## What changed

New **§5.1.3** and an optional `filter` on the subscription request:

```json
{
  "event_types": ["com.example.entity.updated"],
  "filter": {
    "match": "all",
    "conditions": [
      { "path": "subject", "op": "prefix", "value": "listing/" },
      { "path": "data.status", "op": "in", "value": ["published", "archived"] }
    ]
  }
}
```

Operators: `eq`, `ne`, `in`, `nin`, `prefix`, `exists`, `gt`, `lt`. Paths address the whole envelope, so `subject` (from #100) and any `eep_*` attribute are reachable, not just `data`.

## Three design decisions worth reviewing

**1. No regex operator, and deliberately not Turing-complete.** The filter runs on the *publisher's* delivery hot path against every candidate event. A richer language would let a subscriber hand the publisher a catastrophically backtracking pattern to evaluate **at the publisher's expense**. Conditions (20) and path depth (8) are bounded for the same reason. `ROADMAP.md` already plans ReDoS fuzzing on gate-config patterns — this avoids opening a second such surface rather than adding one to the list. There's a negative conformance vector using `^(a+)+$` to pin it.

**2. A malformed filter is rejected with `400`, not ignored.** A subscriber that believes it is filtering but is not receives traffic it thought it had asked to be spared — and cannot detect the difference from its own side.

**3. Filters narrow, never widen, and are not access control.** Gates are applied before filters; a filter cannot reach anything the subscriber's tier does not already grant. A test pins that a permissive filter cannot deliver an event whose type `event_types` never selected.

**One subtlety:** an event that fails the filter is **not** counted as a failed delivery. It was never a candidate — treating it as a failure would eventually pause a perfectly healthy subscription.

## Security

Path traversal into `__proto__` / `constructor` / `prototype` is rejected at validation, **and** the reader ignores inherited properties — so a subscriber-supplied path can never reach a prototype lookup even if validation were bypassed. Both layers are tested.

## Scope

- [x] Spec / schema only
- [x] TypeScript package(s)
- [ ] Python package(s)
- [x] Tests / CI
- [ ] Docs / examples

## Checklist

- [x] I read CONTRIBUTING.md and CODE_OF_CONDUCT.md.
- [x] Tests added or updated where appropriate.
- [x] **Breaking change?** No. `filter` is optional; a subscription without one behaves exactly as before.
- [x] Documentation updated for user-visible behavior.

## Verification

| Suite | Result |
|---|---|
| `@eep-dev/middleware` | **229 passed** (was 189) |
| `tests/` | 191 passed |
| `compliance-cli --fixtures` | **26 vectors**, 0 failed |
| `tests/cross-impl/test_conformance_fixtures.py` | 28 passed |
| `codegen-schema-types --check` | no drift |

## Notes for reviewers

**Webhook batching — the other half of audit finding O4 — is deliberately not here.** It changes the delivery envelope *and* the signing unit (an HMAC over a batch rather than a single event), which deserves its own review rather than riding along with a filtering change. Coming separately.

**No Python middleware parity** for filter evaluation — flagging rather than skipping silently. The schema and spec are language-neutral; only the TS dispatcher enforces it today.