### PR TITLE
docs: correct claims that no longer match the tree

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ MCP, A2A, webhooks and ActivityPub standards solve different problems. EEP compo
 
 - **MCP** lets an LLM *call a tool*. EEP lets an LLM *follow an entity over time* — discover it, subscribe and react to verified events from it.
 - **A2A** lets two agents *collaborate on a task*. EEP defines how either agent learns that an entity changed at all.
-- **Plain webhooks** require a custom protocol per publisher (auth, signing, retries, replay window). EEP is one wire format with HMAC-signed delivery, SSE and a 60-second replay window — implemented once, reusable everywhere.
+- **Plain webhooks** require a custom protocol per publisher (auth, signing, retries, replay window). EEP is one wire format with signed delivery, SSE, and event replay with a minimum 24-hour retention window — implemented once, reusable everywhere.
 - **ActivityPub** federates accounts in a social graph. EEP delivers state-change events from any entity (person org, agent, product, listing) to authorized subscribers, with optional payment / credential / identity gates.
 - **DIDs and Verifiable Credentials** identify *who* an entity is. EEP defines *what they tell their subscribers* and *how subscribers verify it*.
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -26,9 +26,11 @@ Stabilization, hardening, and ecosystem unblocking. Drives toward the
       SBOM, sigstore/cosign keyless signing, GitHub Action SHA pinning
       via Renovate
 - [x] DCO enforcement on every commit to `main`
-- [ ] **Offline conformance fixtures** under `tests/conformance-fixtures/`,
-      consumable by `@eep-dev/compliance-cli --fixtures` without booting a
-      live publisher
+- [x] **Offline conformance fixtures** under `tests/conformance-fixtures/`,
+      consumable by `npx @eep-dev/compliance-cli --fixtures <dir>` without
+      booting a live publisher. The vectors and the release tarball existed
+      before; the CLI flag that made them runnable by anyone outside this
+      repo did not.
 - [ ] **Python feature parity**: `eep-gates` (proof verifier, commerce,
       service listing), `eep-middleware` (Flask/FastAPI/Django adapters)
 - [ ] `py.typed` markers on every Python package; `mypy --strict` clean
@@ -42,8 +44,15 @@ Stabilization, hardening, and ecosystem unblocking. Drives toward the
 
 Quality of life and adoption surface area.
 
-- [ ] **Monorepo migration to pnpm workspaces** with shared
-      `tsconfig.base.json` and a single `pnpm -r test` entry point
+- [x] **Monorepo migration to pnpm workspaces** with shared
+      `tsconfig.base.json` and a single `pnpm -r test` entry point —
+      `pnpm-workspace.yaml`, `tsconfig.base.json` and the root
+      `packageManager: pnpm@9.15.0` all landed. What remains is narrower and
+      tracked separately below.
+- [ ] **Consolidate to a single `pnpm-lock.yaml`.** Per-package
+      `package-lock.json` files still coexist with the pnpm workspace because
+      CI invokes per-package `npm ci`; moving CI to `pnpm -r install` removes
+      N redundant dependency resolutions per run.
 - [ ] **Schema → TypeScript / Pydantic codegen** with a CI drift gate
       (no hand-maintained types diverging from `schemas/v0.1/*.json`)
 - [ ] WebCrypto shim in `@eep-dev/signer` for edge runtimes
@@ -119,6 +128,19 @@ roadmap effort, and instead defers to the named external standard:
 - **Social federation between accounts** — defers to **ActivityPub**.
 
 ---
+
+## Keeping this file honest
+
+A roadmap that drifts from the tree is worse than no roadmap: it hides
+finished work and misrepresents what is left. Two entries had drifted in
+opposite directions — the pnpm migration had shipped while listed as pending,
+and the offline fixtures read as unstarted when only a CLI flag was missing.
+
+When updating an item, check the tree rather than memory:
+
+- "Done" needs a file, a command, or a CI job that demonstrates it.
+- "Not done" needs a check that it is genuinely absent — a partially shipped
+  item should be split so the remaining work is visible on its own.
 
 ## How this roadmap is updated
 

--- a/scripts/decouple-more-md-branding.py
+++ b/scripts/decouple-more-md-branding.py
@@ -1,9 +1,20 @@
+#!/usr/bin/env python3
+"""One-off de-branding pass from the more.md extraction.
+
+EEP was extracted from more.md's codebase and open-sourced; this script
+rewrote the remaining more.md identifiers to neutral examples. It has already
+run, and is kept only so the substitution list is auditable — if a stray
+more.md reference turns up, this records what the mapping was.
+
+It is not part of any build or test. Moved out of the repository root, where
+it was the first thing a new contributor saw.
+"""
 import os
 import re
 
 REPLACEMENTS = [
     (r"Copyright 2026 more\.md", "Copyright 2026 EEP Contributors"),
-    (r"hello@more\.md", "security@eep.dev"),
+    (r"hello@more\.md", "hello@eep.dev"),
     (r"MoreMDEntityCredential", "EEPEntityCredential"),
     (r"more-md SDK", "example SDK"),
     (r"did:web:api\.more\.md", "did:web:api.example.com"),

--- a/tests/conformance-fixtures/README.md
+++ b/tests/conformance-fixtures/README.md
@@ -20,7 +20,7 @@ tests/conformance-fixtures/
 ├── envelope/                ← EEP/CloudEvents event envelope shapes
 ├── signature/               ← HMAC sign + verify, replay window, multi-signature
 ├── gates/                   ← 402 / 403 / 429 / 451 response shapes; access resolution
-└── subscription/            ← subscribe/unsubscribe request and response shapes
+└── subscription/            ← subscribe request shapes, SSRF rejection, leases, filters
 ```
 
 Every fixture directory contains either:


### PR DESCRIPTION
## Summary

**PR 21 of a stacked series — the last one.** Base is #112. **Not for merge without review.**

Four documentation statements that were wrong.

### 1. The README understated the protocol's best reliability feature by ~1440×

> EEP is one wire format with HMAC-signed delivery, SSE and a **60-second replay window**

The 60 seconds is the HMAC **timestamp tolerance** (§5.3). The event **replay** window is a **minimum of 24 hours** (§4.3).

The sentence is positioning EEP against plain webhooks, and durable replay *is* the differentiator — so getting the number wrong made the pitch weaker, not stronger.

### 2. The fixtures README described contents the directory does not have

> `subscription/` ← subscribe/**unsubscribe** request and **response shapes**

There is no unsubscribe vector and there are no response shapes. Corrected to what is actually there.

### 3. `decouple.py` sat at the repository root

A one-off de-branding pass from the more.md extraction that has **already run** — the first thing a new contributor sees in a root listing, and part of no build or test. Moved to `scripts/`, given a header explaining what it was and why it's kept (the substitution list stays auditable), and its security-contact substitution corrected from `security@eep.dev` to **`hello@eep.dev`** — the address `SECURITY.md` and the README actually publish.

### 4. `ROADMAP.md` had drifted in *both* directions

| Item | Listed as | Actually |
|---|---|---|
| pnpm workspace migration | unchecked v0.2 | **shipped** — `pnpm-workspace.yaml`, `tsconfig.base.json`, `packageManager: pnpm@9.15.0`, `pnpm -r` test script all present |
| Offline conformance fixtures | unchecked | vectors, manifest and release tarball all existed; **only the CLI flag was missing** (landed in #95) |

Both are corrected, and the pnpm item is **split** so the residual work — consolidating to a single `pnpm-lock.yaml` — is visible on its own rather than hidden inside a checkbox that looked untouched.

I also added a short note on keeping the file honest: check the tree rather than memory, and split a partially shipped item so the remainder stays visible. A stale roadmap is worse than none — it hides finished work and misrepresents what is left.

## Scope

- [ ] Spec / schema only
- [ ] TypeScript package(s)
- [ ] Python package(s)
- [ ] Tests / CI
- [x] Docs / examples

## Checklist

- [x] I read CONTRIBUTING.md and CODE_OF_CONDUCT.md.
- [x] Tests added or updated where appropriate (none apply — no behaviour changes).
- [x] **Breaking change?** No. Documentation and one file move; no code path, schema or wire format touched.
- [x] Documentation updated for user-visible behavior.

## Verification

Every claim written into the roadmap was checked against the tree rather than asserted:

```console
$ python3 -c "import json;d=json.load(open('package.json'));print(d['packageManager'])"
pnpm@9.15.0
$ ls pnpm-workspace.yaml tsconfig.base.json   # both present
$ grep -c fixtures packages/@eep-dev/compliance-cli/src/index.ts
11
```

| Check | Result |
|---|---|
| `tests/` | 200 passed |
| `tests/cross-impl/` | 56 passed, 3 skipped |
| `codegen-schema-types --check` | no drift |
| `openapi-route-parity` | ✓ |
| Nothing references the old `decouple.py` path | confirmed by grep |

## Notes for reviewers

**I moved `decouple.py` rather than deleting it.** It has served its purpose and could reasonably go, but deleting someone's tool is a call for a maintainer to make — the substitution list is the only record of what the extraction rewrote. Say the word and I'll remove it.

**This is the final PR in the series.** The full stack is #93 → #112 → this one, one PR per audit finding, each based on the previous so the diffs stay reviewable and never conflict. GitHub retargets each to `main` as its base merges.